### PR TITLE
[backend-api] [issue-15] [chore] Go linter 設定

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+golang 1.26.3
+golangci-lint 2.12.2
+nodejs 24.13.0

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      enable-all: true
+    staticcheck:
+      # SA: staticcheck, S: gosimple (merged in v2), QF: quickfix
+      checks: ["SA", "S", "QF"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,29 @@
+BUILD_OPTS = GOOS=linux GOARCH=arm64 CGO_ENABLED=0
+
+.PHONY: up fmt lint mod test build build-api build-event verify
+
+up:
+	go run ./cmd/api
+
+fmt:
+	go fmt ./...
+
+lint:
+	golangci-lint run ./...
+
+mod:
+	go mod tidy
+	git diff --exit-code go.mod go.sum
+
+test:
+	go test -race ./...
+
+build-api:
+	$(BUILD_OPTS) go build -trimpath -o build/api ./cmd/api
+
+build-event:
+	$(BUILD_OPTS) go build -trimpath -o build/event ./cmd/event
+
+build: build-api build-event
+
+verify: fmt lint build test

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/tamaco489/realtime-event-platform/backend
+
+go 1.26.3


### PR DESCRIPTION
## Why

backend で `golangci-lint` を実行できる開発環境を整えるため。
ローカルと CI で同一の lint 設定を共有できるようにする。

## What

- `.tool-versions` を追加し、golang / golangci-lint / nodejs のバージョンを一元管理
- `backend/.golangci.yml` を追加し、errcheck / govet / ineffassign / staticcheck / unused を有効化
- `backend/go.mod` を初期化 (`github.com/tamaco489/realtime-event-platform/backend`)
- `backend/Makefile` に fmt / lint / mod / test / build / verify / up ターゲットを定義

## Where

`backend/` 配下の Go モジュール設定全般。

## Note

> [!NOTE]
> `golangci-lint` は `backend/` 直下に `.golangci.yml` を配置することで、`make lint` (`golangci-lint run ./...`) が正しく設定ファイルを参照する。