### PR TITLE
[backend] [issue-31] [feat] リクエストバリデーション + エラーハンドリング

### DIFF
--- a/backend/internal/handler/api/handler.go
+++ b/backend/internal/handler/api/handler.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io"
+	"encoding/json"
 	"log"
 	"net/http"
 
@@ -14,6 +14,11 @@ func NewHandler(p producer.Producer) *Handler {
 	return &Handler{producer: p}
 }
 
+type postEventsRequest struct {
+	EventType string          `json:"event_type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if err := r.Body.Close(); err != nil {
@@ -21,16 +26,35 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	body, err := io.ReadAll(r.Body)
+	var req postEventsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if req.EventType == "" {
+		writeJSONError(w, "event_type is required", http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(req)
 	if err != nil {
-		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		writeJSONError(w, "failed to marshal request", http.StatusInternalServerError)
 		return
 	}
 
 	if err := h.producer.Send(r.Context(), string(body)); err != nil {
-		http.Error(w, "failed to send message", http.StatusInternalServerError)
+		writeJSONError(w, "failed to send message", http.StatusInternalServerError)
 		return
 	}
 
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func writeJSONError(w http.ResponseWriter, msg string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": msg}); err != nil {
+		log.Println(err)
+	}
 }

--- a/backend/internal/handler/api/handler_test.go
+++ b/backend/internal/handler/api/handler_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockProducer struct {
+	err error
+}
+
+func (m *mockProducer) Send(_ context.Context, _ string) error {
+	return m.err
+}
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		body        string
+		producerErr error
+		wantError   string
+		wantStatus  int
+	}{
+		"正常系_有効なリクエスト": {
+			body:       `{"event_type":"test","payload":{}}`,
+			wantStatus: http.StatusAccepted,
+		},
+		"正常系_payload_にデータを含む": {
+			body:       `{"event_type":"user.created","payload":{"user_id":"u-001"}}`,
+			wantStatus: http.StatusAccepted,
+		},
+		"異常系_不正な_JSON": {
+			body:       `{ invalid }`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid JSON body",
+		},
+		"異常系_event_type_が空": {
+			body:       `{"event_type":"","payload":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "event_type is required",
+		},
+		"異常系_event_type_が欠落": {
+			body:       `{"payload":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "event_type is required",
+		},
+		"異常系_SQS_送信エラー": {
+			body:        `{"event_type":"test","payload":{}}`,
+			producerErr: errors.New("sqs error"),
+			wantStatus:  http.StatusInternalServerError,
+			wantError:   "failed to send message",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler(&mockProducer{err: tt.producerErr})
+			req := httptest.NewRequest(http.MethodPost, "/events", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			h.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if tt.wantError != "" {
+				if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+					t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+				}
+				var resp map[string]string
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response body: %v", err)
+				}
+				if resp["error"] != tt.wantError {
+					t.Errorf("error = %q, want %q", resp["error"], tt.wantError)
+				}
+			}
+		})
+	}
+}

--- a/backend/tools/httprequest/post_events.http
+++ b/backend/tools/httprequest/post_events.http
@@ -22,3 +22,29 @@ Content-Type: application/json
     "name": "tamaco"
   }
 }
+
+###
+# POST /events — 異常系: event_type が空
+POST {{baseUrl}}/events
+Content-Type: application/json
+
+{
+  "event_type": "",
+  "payload": {}
+}
+
+###
+# POST /events — 異常系: event_type が欠落
+POST {{baseUrl}}/events
+Content-Type: application/json
+
+{
+  "payload": {}
+}
+
+###
+# POST /events — 異常系: 不正な JSON ボディ
+POST {{baseUrl}}/events
+Content-Type: application/json
+
+{ invalid json }


### PR DESCRIPTION
## 概要

POST /events ハンドラに JSON バリデーションと統一エラーレスポンスを実装する。
`http.Error` によるプレーンテキスト応答を廃止し、すべてのエラーを `{"error": "..."}` 形式の JSON で返すよう変更した。

## 変更内容

- `postEventsRequest` 構造体で JSON デコードし、パース失敗時に 400 を返す
- `event_type` が空の場合に 400 を返す
- `writeJSONError` ヘルパーで `Content-Type: application/json` + `{"error": "..."}` を統一
- SQS 送信エラー時に 500 を返す
- `.http` ファイルに異常系 3 ケースを追加 (event_type 空・欠落・不正 JSON)

## 関連 Issue / Discussion

- Closes #31

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] `make lint` が通ることを確認
- [x] 関連するテストが通ることを確認 (`make test`)

## レビュー観点

`writeJSONError` は `w.WriteHeader` の前に必ず `w.Header().Set` を呼ぶ順序になっている点を確認してほしい。
ヘッダーセット後に `WriteHeader` を呼ばないと `Content-Type` が反映されない。