### PR TITLE
[ci] [issue-49] [ci] Go lint / build / test ワークフロー (Event Lambda)

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -4,12 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "backend/**"
+      - "backend/cmd/api/**"
+      - "backend/internal/handler/api/**"
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/Makefile"
+      - "backend/.golangci.yml"
       - ".github/workflows/ci-api.yml"
   pull_request:
     branches: [main]
     paths:
-      - "backend/**"
+      - "backend/cmd/api/**"
+      - "backend/internal/handler/api/**"
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/Makefile"
+      - "backend/.golangci.yml"
       - ".github/workflows/ci-api.yml"
 
 concurrency:

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -35,8 +35,24 @@ jobs:
           go-version-file: "backend/go.mod"
           cache-dependency-path: "backend/go.sum"
 
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        id: cache-golangci-lint
+        with:
+          path: ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-v2.12.2
+
       - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('backend/.golangci.yml', 'backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
 
       - name: Lint
         run: make lint

--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -1,0 +1,94 @@
+name: CI - Event
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/ci-event.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/ci-event.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Node.js 24 がデフォルト化される 2026-06-02 以降は削除可
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        id: cache-golangci-lint
+        with:
+          path: ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-v2.12.2
+
+      - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('backend/.golangci.yml', 'backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Build
+        run: make build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Test
+        run: make test

--- a/.github/workflows/ci-event.yml
+++ b/.github/workflows/ci-event.yml
@@ -4,12 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "backend/**"
+      - "backend/cmd/event/**"
+      - "backend/internal/handler/event/**"
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/Makefile"
+      - "backend/.golangci.yml"
       - ".github/workflows/ci-event.yml"
   pull_request:
     branches: [main]
     paths:
-      - "backend/**"
+      - "backend/cmd/event/**"
+      - "backend/internal/handler/event/**"
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/Makefile"
+      - "backend/.golangci.yml"
       - ".github/workflows/ci-event.yml"
 
 concurrency:


### PR DESCRIPTION
## 概要

Event Lambda 用の CI ワークフロー (`ci-event.yml`) を追加する。
合わせて既存の `ci-api.yml` にも golangci-lint キャッシュを追加し、両ワークフローのキャッシュ戦略を統一した。

## 変更内容

- `ci-event.yml` を新規作成 — lint / build / test の 3 ジョブ構成 (`ci-api.yml` と同構成)
- `ci-api.yml` に golangci-lint バイナリキャッシュ・解析キャッシュを追加
- golangci-lint バイナリはバージョン (`v2.12.2`) をキーにキャッシュし、cache-hit 時はインストールをスキップ
- golangci-lint 解析キャッシュは `.golangci.yml` + `go.sum` のハッシュをキーに使用

## 関連 Issue / Discussion

- Closes #49

## 動作確認

- [x] ローカルで `make lint` / `make build` / `make test` が通ることを確認

## レビュー観点

> [!NOTE]
> Event Lambda は `backend/` モジュールに統合済みのため、`ci-event.yml` のパスフィルタは `ci-api.yml` と同じ `backend/**` を使用している。
> `backend/` への変更時は両ワークフローが同時にトリガーされる。