### PR TITLE
[backend] [issue-34] [feat] SQS イベント受信ハンドラー

### DIFF
--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -13,10 +14,20 @@ func NewHandler() *Handler {
 	return &Handler{}
 }
 
+type eventMessage struct {
+	Payload   map[string]any `json:"payload"`
+	EventType string         `json:"event_type"`
+}
+
 func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) error {
 	log.Printf("event handler invoked: records=%d", len(sqsEvent.Records))
 	for _, record := range sqsEvent.Records {
-		log.Printf("message_id=%s body=%s", record.MessageId, record.Body)
+		var msg eventMessage
+		if err := json.Unmarshal([]byte(record.Body), &msg); err != nil {
+			log.Printf("skip: failed to parse record: message_id=%s err=%v", record.MessageId, err)
+			continue
+		}
+		log.Printf("message_id=%s event_type=%s payload=%v", record.MessageId, msg.EventType, msg.Payload)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why

SQS からバッチ受信したメッセージをパースし、各レコードを処理する Event Lambda ハンドラーが未実装だったため追加した。

## What

`internal/handler/event/handler.go` に `Handle()` を実装した。
`events.SQSEvent` の各レコードを `eventMessage` 構造体 (event_type, payload) にパースし、
パースエラー時はそのレコードをスキップして他のレコードの処理を継続する。

## How

- ハンドラーシグネチャ: `func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) error`
- `eventMessage` 構造体はパッケージ内部のみで使用するため非公開 (`eventMessage`)
- `fieldalignment` に従い `Payload map[string]any` を先頭フィールドに配置
- パースエラー時は `log.Printf` でスキップログを出力し `continue` で次レコードへ

Closes #34