### PR TITLE
[backend] [issue-35] [feat] DynamoDB Writer 実装 (interface + mock/real)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ APP_ENV=local
 APP_PORT=8080
 API_SERVICE_NAME=realtime-event-api
 EVENT_SERVICE_NAME=realtime-event-lambda
+DYNAMODB_TABLE_NAME=realtime-event-table

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.29
 	github.com/caarlos0/env/v11 v11.4.1
+	github.com/google/uuid v1.6.0
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -38,6 +38,8 @@ github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSw
 github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=

--- a/backend/internal/library/config/event_config.go
+++ b/backend/internal/library/config/event_config.go
@@ -7,12 +7,17 @@ import (
 )
 
 type EventConfig struct {
-	App EventAppConfig
+	App   EventAppConfig
+	Store StoreConfig
 }
 
 type EventAppConfig struct {
 	Env         Environment `env:"APP_ENV,required,notEmpty"`
 	ServiceName string      `env:"EVENT_SERVICE_NAME,required,notEmpty"`
+}
+
+type StoreConfig struct {
+	TableName string `env:"DYNAMODB_TABLE_NAME"`
 }
 
 func EventLoad() (*EventConfig, error) {

--- a/backend/internal/library/store/client.go
+++ b/backend/internal/library/store/client.go
@@ -2,19 +2,32 @@ package store
 
 import (
 	"context"
+	"log"
+
+	lib_config "github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 )
 
 type store struct {
-	client *dynamodb.Client
+	client    *dynamodb.Client
+	tableName string
 }
 
-func NewStore(ctx context.Context) (*store, error) {
+func NewStore(ctx context.Context, env lib_config.Environment, tableName string) (EventWriter, error) {
+	if env.IsLocal() {
+		log.Println("store: running in mock mode")
+		return &mockWriter{}, nil
+	}
+
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &store{client: dynamodb.NewFromConfig(cfg)}, nil
+
+	return &store{
+		client:    dynamodb.NewFromConfig(cfg),
+		tableName: tableName,
+	}, nil
 }

--- a/backend/internal/library/store/interface.go
+++ b/backend/internal/library/store/interface.go
@@ -1,0 +1,7 @@
+package store
+
+import "context"
+
+type EventWriter interface {
+	PutEvent(ctx context.Context, eventType string, payload map[string]any) error
+}

--- a/backend/internal/library/store/mock.go
+++ b/backend/internal/library/store/mock.go
@@ -1,0 +1,13 @@
+package store
+
+import (
+	"context"
+	"log"
+)
+
+type mockWriter struct{}
+
+func (m *mockWriter) PutEvent(_ context.Context, eventType string, payload map[string]any) error {
+	log.Printf("[MOCK] DynamoDB PutItem: event_type=%s payload=%v\n", eventType, payload)
+	return nil
+}

--- a/backend/internal/library/store/put.go
+++ b/backend/internal/library/store/put.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+)
+
+func (s *store) PutEvent(ctx context.Context, eventType string, payload map[string]any) error {
+	eventID, err := uuid.NewV7()
+	if err != nil {
+		return err
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.tableName),
+		Item: map[string]types.AttributeValue{
+			"event_id":   &types.AttributeValueMemberS{Value: eventID.String()},
+			"event_type": &types.AttributeValueMemberS{Value: eventType},
+			"payload":    &types.AttributeValueMemberS{Value: string(payloadJSON)},
+			"created_at": &types.AttributeValueMemberN{Value: strconv.FormatInt(time.Now().UTC().Unix(), 10)},
+		},
+	})
+	return err
+}


### PR DESCRIPTION
## Why

Event Lambda が SQS メッセージを受信した後、DynamoDB にイベントを永続化する実装が必要なため追加した。

## What

`internal/library/store/` に EventWriter interface と mock/real の 2 実装を追加した。
`NewStore()` ファクトリ関数が APP_ENV に応じて mock と real を切り替える。

## How

- `interface.go`: `PutEvent(ctx, eventType, payload)` を持つ `EventWriter` interface を定義
- `mock.go`: `[MOCK] DynamoDB PutItem` ログ出力のみの `mockWriter` を実装
- `put.go`: UUID v7 で `event_id` を生成し、`payload` を JSON 文字列、`created_at` を Unix timestamp (Number 型) として DynamoDB に PutItem
- `client.go`: `NewStore(ctx, env, tableName)` で APP_ENV=local 時は mock、それ以外は real を返す
- `EventConfig` に `StoreConfig` を追加し、テーブル名を `DYNAMODB_TABLE_NAME` 環境変数で受け取る

> [!NOTE]
> `producer` パッケージと同じ命名規則 (`interface.go` / `mock.go` / `client.go` / put.go) に統一している。

Closes #35