### PR TITLE
[backend] [issue-36] [feat] AppSync Publisher 実装 (interface + mock/real)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,5 @@ APP_PORT=8080
 API_SERVICE_NAME=realtime-event-api
 EVENT_SERVICE_NAME=realtime-event-lambda
 DYNAMODB_TABLE_NAME=realtime-event-table
+APPSYNC_ENDPOINT=https://localhost/graphql
+APPSYNC_API_KEY=da2-local

--- a/backend/cmd/event/main.go
+++ b/backend/cmd/event/main.go
@@ -1,21 +1,35 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/handler/event"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/notifier"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/store"
 )
 
 func main() {
+	ctx := context.Background()
+
 	cfg, err := config.EventLoad()
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	log.Printf("service=%s started", cfg.App.ServiceName)
 
-	h := event.NewHandler()
+	s, err := store.NewStore(ctx, cfg.App.Env, cfg.Store.TableName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	n, err := notifier.NewNotifier(ctx, cfg.App.Env, cfg.Notifier.Endpoint, cfg.Notifier.APIKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	h := event.NewHandler(s, n)
 	lambda.Start(h.Handle)
 }

--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -6,12 +6,17 @@ import (
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/notifier"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/store"
 )
 
-type Handler struct{}
+type Handler struct {
+	store    store.EventWriter
+	notifier notifier.EventPublisher
+}
 
-func NewHandler() *Handler {
-	return &Handler{}
+func NewHandler(s store.EventWriter, n notifier.EventPublisher) *Handler {
+	return &Handler{store: s, notifier: n}
 }
 
 type eventMessage struct {
@@ -27,7 +32,18 @@ func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) error {
 			log.Printf("skip: failed to parse record: message_id=%s err=%v", record.MessageId, err)
 			continue
 		}
-		log.Printf("message_id=%s event_type=%s payload=%v", record.MessageId, msg.EventType, msg.Payload)
+
+		if err := h.store.PutEvent(ctx, msg.EventType, msg.Payload); err != nil {
+			log.Printf("skip: failed to put event: message_id=%s err=%v", record.MessageId, err)
+			continue
+		}
+
+		if err := h.notifier.PublishEvent(ctx, msg.EventType, msg.Payload); err != nil {
+			log.Printf("skip: failed to publish event: message_id=%s err=%v", record.MessageId, err)
+			continue
+		}
+
+		log.Printf("processed: message_id=%s event_type=%s", record.MessageId, msg.EventType)
 	}
 	return nil
 }

--- a/backend/internal/handler/event/handler_test.go
+++ b/backend/internal/handler/event/handler_test.go
@@ -1,0 +1,67 @@
+package event
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type mockStore struct {
+	err error
+}
+
+func (m *mockStore) PutEvent(_ context.Context, _ string, _ map[string]any) error {
+	return m.err
+}
+
+type mockNotifier struct {
+	err error
+}
+
+func (m *mockNotifier) PublishEvent(_ context.Context, _ string, _ map[string]any) error {
+	return m.err
+}
+
+func TestHandler_Handle(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		body        string
+		storeErr    error
+		notifierErr error
+	}{
+		"正常系_有効なレコードを処理できる": {
+			body: `{"event_type":"user.created","payload":{"user_id":"u-001"}}`,
+		},
+		"異常系_不正な_JSON_をスキップする": {
+			body: `{ invalid }`,
+		},
+		"異常系_store_エラーをスキップする": {
+			body:     `{"event_type":"user.created","payload":{}}`,
+			storeErr: errors.New("dynamodb error"),
+		},
+		"異常系_notifier_エラーをスキップする": {
+			body:        `{"event_type":"user.created","payload":{}}`,
+			notifierErr: errors.New("appsync error"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler(&mockStore{err: tt.storeErr}, &mockNotifier{err: tt.notifierErr})
+			sqsEvent := events.SQSEvent{
+				Records: []events.SQSMessage{
+					{MessageId: "test-id", Body: tt.body},
+				},
+			}
+
+			if err := h.Handle(context.Background(), sqsEvent); err != nil {
+				t.Errorf("Handle() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/event/handler_test.go
+++ b/backend/internal/handler/event/handler_test.go
@@ -28,9 +28,9 @@ func TestHandler_Handle(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		body        string
 		storeErr    error
 		notifierErr error
+		body        string
 	}{
 		"正常系_有効なレコードを処理できる": {
 			body: `{"event_type":"user.created","payload":{"user_id":"u-001"}}`,

--- a/backend/internal/library/config/event_config.go
+++ b/backend/internal/library/config/event_config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type EventConfig struct {
-	App   EventAppConfig
-	Store StoreConfig
+	App      EventAppConfig
+	Store    StoreConfig
+	Notifier NotifierConfig
 }
 
 type EventAppConfig struct {
@@ -18,6 +19,11 @@ type EventAppConfig struct {
 
 type StoreConfig struct {
 	TableName string `env:"DYNAMODB_TABLE_NAME"`
+}
+
+type NotifierConfig struct {
+	Endpoint string `env:"APPSYNC_ENDPOINT"`
+	APIKey   string `env:"APPSYNC_API_KEY"`
 }
 
 func EventLoad() (*EventConfig, error) {

--- a/backend/internal/library/notifier/client.go
+++ b/backend/internal/library/notifier/client.go
@@ -2,7 +2,10 @@ package notifier
 
 import (
 	"context"
+	"log"
 	"net/http"
+
+	lib_config "github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
 )
 
 type notifier struct {
@@ -11,10 +14,15 @@ type notifier struct {
 	apiKey   string
 }
 
-func NewNotifier(_ context.Context, endpoint, apiKey string) *notifier {
+func NewNotifier(_ context.Context, env lib_config.Environment, endpoint, apiKey string) (EventPublisher, error) {
+	if env.IsLocal() {
+		log.Println("notifier: running in mock mode")
+		return &mockPublisher{}, nil
+	}
+
 	return &notifier{
 		client:   &http.Client{},
 		endpoint: endpoint,
 		apiKey:   apiKey,
-	}
+	}, nil
 }

--- a/backend/internal/library/notifier/interface.go
+++ b/backend/internal/library/notifier/interface.go
@@ -1,0 +1,7 @@
+package notifier
+
+import "context"
+
+type EventPublisher interface {
+	PublishEvent(ctx context.Context, eventType string, payload map[string]any) error
+}

--- a/backend/internal/library/notifier/mock.go
+++ b/backend/internal/library/notifier/mock.go
@@ -1,0 +1,13 @@
+package notifier
+
+import (
+	"context"
+	"log"
+)
+
+type mockPublisher struct{}
+
+func (m *mockPublisher) PublishEvent(_ context.Context, eventType string, payload map[string]any) error {
+	log.Printf("[MOCK] AppSync PublishEvent: event_type=%s payload=%v\n", eventType, payload)
+	return nil
+}

--- a/backend/internal/library/notifier/publish.go
+++ b/backend/internal/library/notifier/publish.go
@@ -1,0 +1,66 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// TODO: AppSync スキーマ (schema.graphql) 確定後、mutation 名・PublishEventInput 型・レスポンスフィールドを合わせて修正する
+const publishEventMutation = `mutation PublishEvent($input: PublishEventInput!) { publishEvent(input: $input) { eventType } }`
+
+type publishEventInput struct {
+	Payload   map[string]any `json:"payload"`
+	EventType string         `json:"eventType"`
+}
+
+type publishVariables struct {
+	Input publishEventInput `json:"input"`
+}
+
+type graphQLRequest struct {
+	Query     string           `json:"query"`
+	Variables publishVariables `json:"variables"`
+}
+
+func (n *notifier) PublishEvent(ctx context.Context, eventType string, payload map[string]any) error {
+	reqBody := graphQLRequest{
+		Query: publishEventMutation,
+		Variables: publishVariables{
+			Input: publishEventInput{
+				Payload:   payload,
+				EventType: eventType,
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", n.apiKey)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("appsync: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
## Why

Event Lambda が DynamoDB にイベントを保存した後、AppSync Mutation でフロントエンドにリアルタイム Push する実装が必要なため追加した。

## What

`internal/library/notifier/` に EventPublisher interface と mock/real の 2 実装を追加した。
`NewNotifier()` ファクトリ関数が APP_ENV に応じて mock と real を切り替える。
ハンドラーに store・notifier を注入し、DynamoDB PutItem → AppSync PublishEvent の順で処理するよう統合した。

## How

- `interface.go`: `PublishEvent(ctx, eventType, payload)` を持つ `EventPublisher` interface を定義
- `mock.go`: `[MOCK] AppSync PublishEvent` ログ出力のみの `mockPublisher` を実装
- `publish.go`: `net/http` で AppSync GraphQL エンドポイントに POST し `x-api-key` ヘッダーを付与。GraphQL mutation 文字列はスキーマ確定後に修正が必要なため TODO コメントを記載
- `client.go`: `NewNotifier(ctx, env, endpoint, apiKey)` で APP_ENV=local 時は mock、それ以外は real を返す
- `handler.go`: store/notifier を依存注入し、各エラー時はスキップして次レコードを継続処理
- `EventConfig` に `NotifierConfig` を追加し `APPSYNC_ENDPOINT` / `APPSYNC_API_KEY` 環境変数で受け取る

> [!NOTE]
> `publish.go` の GraphQL mutation 文字列は INFRA-002 (AppSync スキーマ定義) 完了後に合わせて修正する。

Closes #36