### PR TITLE
[backend] [issue-37] [feat] DLQ 対応 (パーシャルバッチ失敗)

### DIFF
--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -32,8 +32,9 @@ func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) (events.
 	for _, record := range sqsEvent.Records {
 		if err := h.processRecord(ctx, record); err != nil {
 			log.Printf("failure: message_id=%s err=%v", record.MessageId, err)
-			// 失敗レコードの messageId を BatchItemFailures に積む
-			// SQS はこのリストを見て該当レコードのみ再試行し、maxReceiveCount を超えたものだけ DLQ に移動する
+			// パーシャルバッチ失敗: 失敗レコードの messageId だけを BatchItemFailures に積む
+			// SQS はこのリストを見て失敗レコードのみ再試行し、成功レコードはキューから削除する
+			// 再試行が maxReceiveCount を超えたレコードだけ DLQ に移動する
 			resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
 				ItemIdentifier: record.MessageId,
 			})

--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -24,26 +24,39 @@ type eventMessage struct {
 	EventType string         `json:"event_type"`
 }
 
-func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) error {
+func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) (events.SQSEventResponse, error) {
 	log.Printf("event handler invoked: records=%d", len(sqsEvent.Records))
+
+	var resp events.SQSEventResponse
+
 	for _, record := range sqsEvent.Records {
-		var msg eventMessage
-		if err := json.Unmarshal([]byte(record.Body), &msg); err != nil {
-			log.Printf("skip: failed to parse record: message_id=%s err=%v", record.MessageId, err)
-			continue
+		if err := h.processRecord(ctx, record); err != nil {
+			log.Printf("failure: message_id=%s err=%v", record.MessageId, err)
+			// 失敗レコードの messageId を BatchItemFailures に積む
+			// SQS はこのリストを見て該当レコードのみ再試行し、maxReceiveCount を超えたものだけ DLQ に移動する
+			resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
+				ItemIdentifier: record.MessageId,
+			})
 		}
-
-		if err := h.store.PutEvent(ctx, msg.EventType, msg.Payload); err != nil {
-			log.Printf("skip: failed to put event: message_id=%s err=%v", record.MessageId, err)
-			continue
-		}
-
-		if err := h.notifier.PublishEvent(ctx, msg.EventType, msg.Payload); err != nil {
-			log.Printf("skip: failed to publish event: message_id=%s err=%v", record.MessageId, err)
-			continue
-		}
-
-		log.Printf("processed: message_id=%s event_type=%s", record.MessageId, msg.EventType)
 	}
+
+	return resp, nil
+}
+
+func (h *Handler) processRecord(ctx context.Context, record events.SQSMessage) error {
+	var msg eventMessage
+	if err := json.Unmarshal([]byte(record.Body), &msg); err != nil {
+		return err
+	}
+
+	if err := h.store.PutEvent(ctx, msg.EventType, msg.Payload); err != nil {
+		return err
+	}
+
+	if err := h.notifier.PublishEvent(ctx, msg.EventType, msg.Payload); err != nil {
+		return err
+	}
+
+	log.Printf("processed: message_id=%s event_type=%s", record.MessageId, msg.EventType)
 	return nil
 }

--- a/backend/internal/handler/event/handler_test.go
+++ b/backend/internal/handler/event/handler_test.go
@@ -28,23 +28,27 @@ func TestHandler_Handle(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		storeErr    error
-		notifierErr error
-		body        string
+		storeErr       error
+		notifierErr    error
+		body           string
+		wantFailureIDs []string
 	}{
 		"正常系_有効なレコードを処理できる": {
 			body: `{"event_type":"user.created","payload":{"user_id":"u-001"}}`,
 		},
-		"異常系_不正な_JSON_をスキップする": {
-			body: `{ invalid }`,
+		"異常系_不正な_JSON_は_BatchItemFailures_に積まれる": {
+			body:           `{ invalid }`,
+			wantFailureIDs: []string{"test-id"},
 		},
-		"異常系_store_エラーをスキップする": {
-			body:     `{"event_type":"user.created","payload":{}}`,
-			storeErr: errors.New("dynamodb error"),
+		"異常系_store_エラーは_BatchItemFailures_に積まれる": {
+			body:           `{"event_type":"user.created","payload":{}}`,
+			storeErr:       errors.New("dynamodb error"),
+			wantFailureIDs: []string{"test-id"},
 		},
-		"異常系_notifier_エラーをスキップする": {
-			body:        `{"event_type":"user.created","payload":{}}`,
-			notifierErr: errors.New("appsync error"),
+		"異常系_notifier_エラーは_BatchItemFailures_に積まれる": {
+			body:           `{"event_type":"user.created","payload":{}}`,
+			notifierErr:    errors.New("appsync error"),
+			wantFailureIDs: []string{"test-id"},
 		},
 	}
 
@@ -59,8 +63,20 @@ func TestHandler_Handle(t *testing.T) {
 				},
 			}
 
-			if err := h.Handle(context.Background(), sqsEvent); err != nil {
+			resp, err := h.Handle(context.Background(), sqsEvent)
+			if err != nil {
 				t.Errorf("Handle() error = %v, want nil", err)
+			}
+
+			if len(resp.BatchItemFailures) != len(tt.wantFailureIDs) {
+				t.Errorf("BatchItemFailures len = %d, want %d", len(resp.BatchItemFailures), len(tt.wantFailureIDs))
+				return
+			}
+
+			for i, id := range tt.wantFailureIDs {
+				if resp.BatchItemFailures[i].ItemIdentifier != id {
+					t.Errorf("BatchItemFailures[%d] = %q, want %q", i, resp.BatchItemFailures[i].ItemIdentifier, id)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Why

従来の実装では処理失敗レコードを `continue` でスキップするだけだったため、Lambda は SQS バッチ全体を成功扱いにしていた。
そのため失敗したレコードが DLQ に移動されず、再試行もされないという問題があった。

## What

`Handle()` の戻り値を `error` から `(events.SQSEventResponse, error)` に変更した。
処理失敗したレコードの `messageId` を `BatchItemFailures` に積むことで、SQS が該当レコードのみを再試行し、`maxReceiveCount` を超えたものだけ DLQ に移動するようにした。

## How

- `Handle()` でバッチ全体のレスポンス `SQSEventResponse` を構築し、失敗レコードを `BatchItemFailures` に追加
- 処理ロジックを `processRecord()` に分離し、エラーを呼び出し元に返す形に整理
- CDK 側 (INFRA-007) で `reportBatchItemFailures` を有効化することで本機能が機能する

> [!NOTE]
> INFRA-007 の `reportBatchItemFailures` 有効化と合わせて初めて DLQ 連携が動作する。

Closes #37