### PR TITLE
[infra] [issue-41] [feat] SQS キュー + DLQ 定義

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -24,7 +24,7 @@ diff: build
 	AWS_PROFILE=$(AWS_PROFILE) npx cdk diff
 
 deploy: build
-	AWS_PROFILE=$(AWS_PROFILE) npx cdk deploy --require-approval never
+	AWS_PROFILE=$(AWS_PROFILE) npx cdk deploy
 
 destroy:
 	AWS_PROFILE=$(AWS_PROFILE) npx cdk destroy --force

--- a/infra/lib/constructs/sqs-queue.ts
+++ b/infra/lib/constructs/sqs-queue.ts
@@ -1,0 +1,48 @@
+import * as cdk from "aws-cdk-lib";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+
+/** SqsQueue コンストラクタプロパティ */
+interface SqsQueueProps {
+  readonly envName: string;
+}
+
+/** SQS main queue + DLQ construct */
+export class SqsQueue extends Construct {
+  /** main queue */
+  readonly queue: sqs.Queue;
+
+  /** dlq (dead letter queue) */
+  readonly dlq: sqs.Queue;
+
+  constructor(scope: Construct, id: string, props: SqsQueueProps) {
+    super(scope, id);
+
+    // dlq
+    this.dlq = new sqs.Queue(this, "Dlq", {
+      queueName: `realtime-event-dlq-${props.envName}`,
+      retentionPeriod: cdk.Duration.days(7), // dlq のメッセージ保持期間
+    });
+
+    // main queue (dlq を関連付けて作成)
+    this.queue = new sqs.Queue(this, "Queue", {
+      queueName: `realtime-event-queue-${props.envName}`,
+      visibilityTimeout: cdk.Duration.seconds(30), // Lambda 処理中に他のコンシューマーへ同一メッセージを渡さない時間
+      retentionPeriod: cdk.Duration.days(3), // main queue のメッセージ保持期間
+      deadLetterQueue: {
+        queue: this.dlq,
+        maxReceiveCount: 3, // 3 回失敗で dlq に移動
+      },
+    });
+
+    new cdk.CfnOutput(scope, "SqsQueueUrl", {
+      value: this.queue.queueUrl,
+      description: "SQS main queue URL",
+    });
+
+    new cdk.CfnOutput(scope, "SqsDlqArn", {
+      value: this.dlq.queueArn,
+      description: "SQS dead letter queue ARN",
+    });
+  }
+}

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -3,6 +3,7 @@ import { Construct } from "constructs";
 
 import { EnvConfig } from "../../config/env-config";
 import { AppSyncApi } from "../constructs/appsync-api";
+import { SqsQueue } from "../constructs/sqs-queue";
 
 /**
  * RealtimeEventStack のコンストラクタプロパティ
@@ -25,6 +26,10 @@ export class RealtimeEventStack extends cdk.Stack {
     super(scope, id, props);
 
     new AppSyncApi(this, "AppSyncApi", {
+      envName: props.config.envName,
+    });
+
+    new SqsQueue(this, "SqsQueue", {
       envName: props.config.envName,
     });
   }

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -21,6 +21,21 @@ exports[`snapshot 1`] = `
         ],
       },
     },
+    "SqsDlqArn": {
+      "Description": "SQS dead letter queue ARN",
+      "Value": {
+        "Fn::GetAtt": [
+          "SqsQueueDlq1151B914",
+          "Arn",
+        ],
+      },
+    },
+    "SqsQueueUrl": {
+      "Description": "SQS main queue URL",
+      "Value": {
+        "Ref": "SqsQueueB359A2D7",
+      },
+    },
   },
   "Parameters": {
     "BootstrapVersion": {
@@ -96,6 +111,34 @@ schema {
 ",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
+    },
+    "SqsQueueB359A2D7": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 259200,
+        "QueueName": "realtime-event-queue-dev",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "SqsQueueDlq1151B914",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
+        "VisibilityTimeout": 30,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "SqsQueueDlq1151B914": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 604800,
+        "QueueName": "realtime-event-dlq-dev",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
   },
   "Rules": {


### PR DESCRIPTION
## 概要

SQS メインキューと DLQ を CDK コンストラクトとして定義した。
3 回処理失敗したメッセージを DLQ に移動し、キュー URL と DLQ ARN を Stack Output に出力する。

## 変更内容

- `lib/constructs/sqs-queue.ts` を新規作成し、メインキュー + DLQ を定義
- `lib/stacks/realtime-event-stack.ts` に `SqsQueue` コンストラクトを組み込み
- `Makefile` の `deploy` から `--require-approval never` を削除し、対話的に確認できるよう変更

## 関連 Issue / Discussion

- Closes #41
- Ref https://github.com/tamaco489/realtime-event-platform/discussions/13

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] `cdk diff` でメインキュー + DLQ が CloudFormation に出力されることを確認 (`maxReceiveCount: 3`)
- [x] `cdk deploy` で `realtime-event-queue-dev` / `realtime-event-dlq-dev` が作成されることを確認

## レビュー観点

メインキューの `visibilityTimeout` (30s) は Lambda のタイムアウトと合わせる必要があるため、Lambda 実装時に見直しが必要。