### PR TITLE
[infra] [issue-43] [feat] API Lambda コンストラクト

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,8 +13,8 @@ mod: fmt
 	go mod tidy
 
 build: mod
-	$(BUILD_OPTS) go build -trimpath -o build/api ./cmd/api
-	$(BUILD_OPTS) go build -trimpath -o build/event ./cmd/event
+	$(BUILD_OPTS) go build -trimpath -o build/api/bootstrap ./cmd/api
+	$(BUILD_OPTS) go build -trimpath -o build/event/bootstrap ./cmd/event
 
 lint:
 	golangci-lint run ./...

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,11 +1,13 @@
-BUILD_OPTS = GOOS=linux GOARCH=arm64 CGO_ENABLED=0
+BUILD_OPTS   = GOOS=linux GOARCH=arm64 CGO_ENABLED=0
+AWS_PROFILE ?= default
+ENV         ?= prd
 
 .PHONY: setup-tools
 setup-tools:
 	go install github.com/tamaco489/lambda-emulator/cmd/emulator@latest
 
 
-.PHONY: fmt lint mod build build-api build-event test verify
+.PHONY: fmt lint mod build test verify
 fmt:
 	go fmt ./...
 
@@ -39,3 +41,33 @@ logs:
 .PHONY: run-event
 run-event:
 	_LAMBDA_SERVER_PORT=9000 APP_ENV=local EVENT_SERVICE_NAME=realtime-event-lambda go run ./cmd/event
+
+
+S3_BUCKET   ?= $(ENV)-realtime-event-storage
+
+.PHONY: upload-api upload-event upload update-api update-event
+upload-api:
+	$(BUILD_OPTS) go build -trimpath -o build/api/bootstrap ./cmd/api
+	zip -j build/api/bootstrap.zip build/api/bootstrap
+	aws s3 cp build/api/bootstrap.zip s3://$(S3_BUCKET)/artifacts/api/bootstrap.zip --profile $(AWS_PROFILE)
+
+upload-event:
+	$(BUILD_OPTS) go build -trimpath -o build/event/bootstrap ./cmd/event
+	zip -j build/event/bootstrap.zip build/event/bootstrap
+	aws s3 cp build/event/bootstrap.zip s3://$(S3_BUCKET)/artifacts/event/bootstrap.zip --profile $(AWS_PROFILE)
+
+upload: upload-api upload-event
+
+deploy-api:
+	aws lambda update-function-code \
+		--function-name $(ENV)-realtime-event-api \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-key artifacts/api/bootstrap.zip \
+		--profile $(AWS_PROFILE)
+
+deploy-event:
+	aws lambda update-function-code \
+		--function-name $(ENV)-realtime-event-event \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-key artifacts/event/bootstrap.zip \
+		--profile $(AWS_PROFILE)

--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/notifier"
@@ -49,6 +50,9 @@ func (h *Handler) processRecord(ctx context.Context, record events.SQSMessage) e
 	if err := json.Unmarshal([]byte(record.Body), &msg); err != nil {
 		return err
 	}
+
+	// NOTE: イベントの処理に時間がかかるケースを想定して、敢えて Sleep で遅延させている
+	time.Sleep(3 * time.Second)
 
 	if err := h.store.PutEvent(ctx, msg.EventType, msg.Payload); err != nil {
 		return err

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -73,7 +73,7 @@ realtime-event-platform/
 
 ### 前提条件
 
-- Go 1.24.x ([asdf](https://asdf-vm.com/) で管理)
+- Go 1.26.x ([asdf](https://asdf-vm.com/) で管理)
 - Node.js 24.x (asdf で管理)
 - AWS CDK CLI (`npm install -g aws-cdk`)
 - AWS CLI (適切なクレデンシャルで設定済み)
@@ -118,4 +118,46 @@ make diff AWS_PROFILE=<your-profile>
 
 # AWS へデプロイ
 make deploy AWS_PROFILE=<your-profile>
+```
+
+## デプロイ
+
+Lambda のコード更新とインフラ変更は独立して管理する。
+
+### Lambda コードの更新
+
+CDK はインフラ定義のみを管理する。Lambda バイナリの更新は `backend/Makefile` のコマンドで行う。
+
+```bash
+cd backend
+
+# ビルド → S3 アップロード → Lambda 反映を一括実行
+make deploy-lambda AWS_PROFILE=<your-profile> ENV=<env>
+
+# 個別に実行する場合
+make upload-api AWS_PROFILE=<your-profile>    # API Lambda を S3 にアップロード
+make upload-event AWS_PROFILE=<your-profile>  # Event Lambda を S3 にアップロード
+make deploy-api AWS_PROFILE=<your-profile>    # API Lambda のコードを更新
+make deploy-event AWS_PROFILE=<your-profile>  # Event Lambda のコードを更新
+```
+
+アップロード先の S3 パス:
+
+```text
+{ENV}-realtime-event-storage/
+  └── artifacts/
+      ├── api/bootstrap.zip
+      └── event/bootstrap.zip
+```
+
+### インフラの更新
+
+CDK でリソース定義を変更した場合は `infra/Makefile` のコマンドで反映する。
+
+```bash
+cd infra
+
+# 変更内容を確認してからデプロイ
+make diff AWS_PROFILE=<your-profile> ENV=<env>
+make deploy AWS_PROFILE=<your-profile> ENV=<env>
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ realtime-event-platform/
 
 ### Prerequisites
 
-- Go 1.24.x (managed via [asdf](https://asdf-vm.com/))
+- Go 1.26.x (managed via [asdf](https://asdf-vm.com/))
 - Node.js 24.x (managed via asdf)
 - AWS CDK CLI (`npm install -g aws-cdk`)
 - AWS CLI (configured with appropriate credentials)
@@ -118,4 +118,46 @@ make diff AWS_PROFILE=<your-profile>
 
 # Deploy to AWS
 make deploy AWS_PROFILE=<your-profile>
+```
+
+## Deployment
+
+Lambda code updates and infrastructure changes are managed independently.
+
+### Lambda Code Update
+
+CDK manages only infrastructure definitions. Lambda binary updates are handled via `backend/Makefile`.
+
+```bash
+cd backend
+
+# Build → upload to S3 → update Lambda in one command
+make deploy-lambda AWS_PROFILE=<your-profile> ENV=<env>
+
+# Run individually
+make upload-api AWS_PROFILE=<your-profile>    # Upload API Lambda to S3
+make upload-event AWS_PROFILE=<your-profile>  # Upload Event Lambda to S3
+make deploy-api AWS_PROFILE=<your-profile>    # Update API Lambda code
+make deploy-event AWS_PROFILE=<your-profile>  # Update Event Lambda code
+```
+
+S3 upload paths:
+
+```text
+{ENV}-realtime-event-storage/
+  └── artifacts/
+      ├── api/bootstrap.zip
+      └── event/bootstrap.zip
+```
+
+### Infrastructure Update
+
+When CDK resource definitions change, apply them via `infra/Makefile`.
+
+```bash
+cd infra
+
+# Review changes before deploying
+make diff AWS_PROFILE=<your-profile> ENV=<env>
+make deploy AWS_PROFILE=<your-profile> ENV=<env>
 ```

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,4 +1,5 @@
 AWS_PROFILE ?= default
+ENV ?= dev
 
 .PHONY: fmt build lint test verify
 fmt:
@@ -18,16 +19,16 @@ verify: build lint test
 
 .PHONY: synth diff deploy destroy
 synth: build
-	AWS_PROFILE=$(AWS_PROFILE) npx cdk synth
+	ENV=$(ENV) AWS_PROFILE=$(AWS_PROFILE) npx cdk synth
 
 diff: build
-	AWS_PROFILE=$(AWS_PROFILE) npx cdk diff
+	ENV=$(ENV) AWS_PROFILE=$(AWS_PROFILE) npx cdk diff
 
 deploy: build
-	AWS_PROFILE=$(AWS_PROFILE) npx cdk deploy
+	ENV=$(ENV) AWS_PROFILE=$(AWS_PROFILE) npx cdk deploy
 
 destroy:
-	AWS_PROFILE=$(AWS_PROFILE) npx cdk destroy --force
+	ENV=$(ENV) AWS_PROFILE=$(AWS_PROFILE) npx cdk destroy --force
 
 
 .PHONY: bootstrap

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -10,22 +10,27 @@
  */
 import * as cdk from "aws-cdk-lib";
 import { RealtimeEventStack } from "../lib/stacks/realtime-event-stack";
-import { devConfig } from "../config/env-config";
+import { devConfig, prdConfig } from "../config/env-config";
 
 const app = new cdk.App();
 
-new RealtimeEventStack(app, `RealtimeEventStack-${devConfig.envName}`, {
+const config = process.env.ENV === "prd" ? prdConfig : devConfig;
+
+const envNamePascal =
+  config.envName.charAt(0).toUpperCase() + config.envName.slice(1);
+
+new RealtimeEventStack(app, `${envNamePascal}RealtimeEventStack`, {
   description: "Realtime event delivery platform based on AppSync Subscription",
   /**
    * cdk bootstrap 時に指定した qualifier と一致させる必要がある。
    * qualifier が異なると CDK bootstrap ロールの assume に失敗する。
    */
   synthesizer: new cdk.DefaultStackSynthesizer({
-    qualifier: devConfig.bootstrapQualifier,
+    qualifier: config.bootstrapQualifier,
   }),
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  config: devConfig,
+  config,
 });

--- a/infra/config/env-config.ts
+++ b/infra/config/env-config.ts
@@ -18,6 +18,9 @@ export interface EnvConfig {
 
   /** Lambda 関数のメモリサイズ (MB) */
   readonly lambdaMemorySize: number;
+
+  /** Lambda ビルド成果物を格納する S3 バケット名 */
+  readonly artifactsBucketName: string;
 }
 
 /** 開発環境設定 */
@@ -25,6 +28,7 @@ export const devConfig: EnvConfig = {
   envName: "dev",
   bootstrapQualifier: "tamaco489",
   lambdaMemorySize: 128,
+  artifactsBucketName: "dev-realtime-event-storage",
 };
 
 /** 本番環境設定 */
@@ -32,4 +36,5 @@ export const prdConfig: EnvConfig = {
   envName: "prd",
   bootstrapQualifier: "tamaco489",
   lambdaMemorySize: 128,
+  artifactsBucketName: "prd-realtime-event-storage",
 };

--- a/infra/config/env-config.ts
+++ b/infra/config/env-config.ts
@@ -26,3 +26,10 @@ export const devConfig: EnvConfig = {
   bootstrapQualifier: "tamaco489",
   lambdaMemorySize: 128,
 };
+
+/** 本番環境設定 */
+export const prdConfig: EnvConfig = {
+  envName: "prd",
+  bootstrapQualifier: "tamaco489",
+  lambdaMemorySize: 128,
+};

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -1,10 +1,9 @@
-import * as path from "path";
-
 import * as cdk from "aws-cdk-lib";
 import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
 import * as sqs from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 
@@ -14,11 +13,13 @@ import { Construct } from "constructs";
  * @property envName - 環境名。リソースの命名に使用する
  * @property queue - SQS メインキュー。Lambda 環境変数と SendMessage 権限付与に使用する
  * @property lambdaMemorySize - Lambda 関数のメモリサイズ (MB)
+ * @property artifactsBucketName - Lambda ビルド成果物を格納する S3 バケット名
  */
 interface ApiLambdaProps {
   readonly envName: string;
   readonly queue: sqs.Queue;
   readonly lambdaMemorySize: number;
+  readonly artifactsBucketName: string;
 }
 
 /**
@@ -57,9 +58,15 @@ export class ApiLambda extends Construct {
       runtime: lambda.Runtime.PROVIDED_AL2023,
       architecture: lambda.Architecture.ARM_64,
       handler: "bootstrap",
-      // backend/build/api に go build -trimpath -o build/api ./cmd/api でビルドしたバイナリを配置する
-      code: lambda.Code.fromAsset(
-        path.join(__dirname, "../../../backend/build/api"),
+      // make upload-api で s3://{artifactsBucketName}/artifacts/api/bootstrap.zip にアップロードされたバイナリを参照する
+      // objectVersion は指定しない設計。Lambda のコード更新は cdk deploy ではなく make deploy-api で行う
+      code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(
+          this,
+          "ArtifactsBucket",
+          props.artifactsBucketName,
+        ),
+        "artifacts/api/bootstrap.zip",
       ),
       role,
       memorySize: props.lambdaMemorySize,

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -40,6 +40,7 @@ export class ApiLambda extends Construct {
     const role = new iam.Role(this, "Role", {
       roleName: `${props.envName}-realtime-event-api-lambda-role`,
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      // ref: https://docs.aws.amazon.com/ja_jp/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html
       managedPolicies: [
         iam.ManagedPolicy.fromAwsManagedPolicyName(
           "service-role/AWSLambdaBasicExecutionRole",
@@ -60,6 +61,9 @@ export class ApiLambda extends Construct {
       ),
       role,
       memorySize: props.lambdaMemorySize,
+      // HTTP API (v2) の統合タイムアウト上限は 30 秒のため、1 秒のバッファを設けて 29 秒に設定する
+      // @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-quotas.html
+      // > Maximum integration timeout | 30 seconds
       timeout: cdk.Duration.seconds(29),
       environment: {
         SQS_QUEUE_URL: props.queue.queueUrl,

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -70,7 +70,7 @@ export class ApiLambda extends Construct {
       },
     });
 
-    props.queue.grantSendMessages(this.fn);
+    props.queue.grantSendMessages(this.fn); // Lambda の IAM ロールに SQS SendMessage 権限を付与する
 
     this.httpApi = new apigwv2.HttpApi(this, "HttpApi", {
       apiName: `${props.envName}-realtime-event-http-api`,

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -1,0 +1,82 @@
+import * as path from "path";
+
+import * as cdk from "aws-cdk-lib";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+
+/**
+ * ApiLambda コンストラクタプロパティ
+ *
+ * @property envName - 環境名。リソースの命名に使用する
+ * @property queue - SQS メインキュー。Lambda 環境変数と SendMessage 権限付与に使用する
+ * @property lambdaMemorySize - Lambda 関数のメモリサイズ (MB)
+ */
+interface ApiLambdaProps {
+  readonly envName: string;
+  readonly queue: sqs.Queue;
+  readonly lambdaMemorySize: number;
+}
+
+/**
+ * API Lambda + API Gateway v2 (HTTP API) コンストラクト
+ *
+ * arm64 / provided.al2023 で Lambda を定義し、HTTP API 経由で外部公開する。
+ * IAM 実行ロールに SQS SendMessage 権限を付与し、エンドポイント URL を Stack Output に出力する。
+ */
+export class ApiLambda extends Construct {
+  /** API Lambda 関数 */
+  readonly fn: lambda.Function;
+
+  /** HTTP API */
+  readonly httpApi: apigwv2.HttpApi;
+
+  constructor(scope: Construct, id: string, props: ApiLambdaProps) {
+    super(scope, id);
+
+    const role = new iam.Role(this, "Role", {
+      roleName: `${props.envName}-realtime-event-api-lambda-role`,
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaBasicExecutionRole",
+        ),
+      ],
+    });
+
+    this.fn = new lambda.Function(this, "Function", {
+      functionName: `${props.envName}-realtime-event-api`,
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      architecture: lambda.Architecture.ARM_64,
+      handler: "bootstrap",
+      // backend/build/api に go build -trimpath -o build/api ./cmd/api でビルドしたバイナリを配置する
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, "../../../backend/build/api"),
+      ),
+      role,
+      memorySize: props.lambdaMemorySize,
+      timeout: cdk.Duration.seconds(29),
+      environment: {
+        SQS_QUEUE_URL: props.queue.queueUrl,
+      },
+    });
+
+    props.queue.grantSendMessages(this.fn);
+
+    this.httpApi = new apigwv2.HttpApi(this, "HttpApi", {
+      apiName: `${props.envName}-realtime-event-http-api`,
+      defaultIntegration: new integrations.HttpLambdaIntegration(
+        "Integration",
+        this.fn,
+      ),
+    });
+
+    new cdk.CfnOutput(scope, "ApiEndpointUrl", {
+      value: this.httpApi.apiEndpoint,
+      description: "API Gateway HTTP API endpoint URL",
+    });
+  }
+}

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -49,6 +49,8 @@ export class ApiLambda extends Construct {
 
     this.fn = new lambda.Function(this, "Function", {
       functionName: `${props.envName}-realtime-event-api`,
+      description:
+        "Receives HTTP requests via API Gateway and publishes events to SQS",
       runtime: lambda.Runtime.PROVIDED_AL2023,
       architecture: lambda.Architecture.ARM_64,
       handler: "bootstrap",
@@ -68,6 +70,7 @@ export class ApiLambda extends Construct {
 
     this.httpApi = new apigwv2.HttpApi(this, "HttpApi", {
       apiName: `${props.envName}-realtime-event-http-api`,
+      description: "HTTP API for the realtime event delivery platform",
       defaultIntegration: new integrations.HttpLambdaIntegration(
         "Integration",
         this.fn,

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -37,6 +37,7 @@ export class ApiLambda extends Construct {
   constructor(scope: Construct, id: string, props: ApiLambdaProps) {
     super(scope, id);
 
+    // Lambda 実行 Role
     const role = new iam.Role(this, "Role", {
       roleName: `${props.envName}-realtime-event-api-lambda-role`,
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -48,6 +49,7 @@ export class ApiLambda extends Construct {
       ],
     });
 
+    // Lambda 関数
     this.fn = new lambda.Function(this, "Function", {
       functionName: `${props.envName}-realtime-event-api`,
       description:
@@ -70,8 +72,10 @@ export class ApiLambda extends Construct {
       },
     });
 
-    props.queue.grantSendMessages(this.fn); // Lambda の IAM ロールに SQS SendMessage 権限を付与する
+    // Lambda の IAM Role に SQS SendMessage 権限を付与
+    props.queue.grantSendMessages(this.fn);
 
+    // HTTP API
     this.httpApi = new apigwv2.HttpApi(this, "HttpApi", {
       apiName: `${props.envName}-realtime-event-http-api`,
       description: "HTTP API for the realtime event delivery platform",

--- a/infra/lib/constructs/appsync-api.ts
+++ b/infra/lib/constructs/appsync-api.ts
@@ -29,7 +29,7 @@ export class AppSyncApi extends Construct {
     super(scope, id);
 
     this.api = new appsync.GraphqlApi(this, "Api", {
-      name: `realtime-event-api-${props.envName}`,
+      name: `${props.envName}-realtime-event-api`,
       // __dirname (このファイルと同階層) の schema.graphql を cdk synth 時にインライン展開する
       definition: appsync.Definition.fromFile(
         path.join(__dirname, "schema.graphql"),

--- a/infra/lib/constructs/dynamodb-table.ts
+++ b/infra/lib/constructs/dynamodb-table.ts
@@ -23,10 +23,10 @@ export class DynamoDbTable extends Construct {
     super(scope, id);
 
     this.table = new dynamodb.Table(this, "Table", {
-      tableName: `realtime-event-table-${props.envName}`,
+      tableName: `${props.envName}-realtime-event-table`,
       partitionKey: { name: "event_id", type: dynamodb.AttributeType.STRING }, // パーティションキーは event_id (UUID 文字列) 固定
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.RETAIN, // スタック削除時もテーブルを保持する
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
     });
 
     new cdk.CfnOutput(scope, "DynamoDbTableName", {

--- a/infra/lib/constructs/sqs-queue.ts
+++ b/infra/lib/constructs/sqs-queue.ts
@@ -29,13 +29,13 @@ export class SqsQueue extends Construct {
 
     // dlq
     this.dlq = new sqs.Queue(this, "Dlq", {
-      queueName: `realtime-event-dlq-${props.envName}`,
+      queueName: `${props.envName}-realtime-event-dlq`,
       retentionPeriod: cdk.Duration.days(7), // dlq のメッセージ保持期間
     });
 
     // main queue (dlq を関連付けて作成)
     this.queue = new sqs.Queue(this, "Queue", {
-      queueName: `realtime-event-queue-${props.envName}`,
+      queueName: `${props.envName}-realtime-event-queue`,
       visibilityTimeout: cdk.Duration.seconds(30), // Lambda 処理中に他のコンシューマーへ同一メッセージを渡さない時間
       retentionPeriod: cdk.Duration.days(3), // main queue のメッセージ保持期間
       deadLetterQueue: {

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import { EnvConfig } from "../../config/env-config";
+import { ApiLambda } from "../constructs/api-lambda";
 import { AppSyncApi } from "../constructs/appsync-api";
 import { DynamoDbTable } from "../constructs/dynamodb-table";
 import { SqsQueue } from "../constructs/sqs-queue";
@@ -30,12 +31,18 @@ export class RealtimeEventStack extends cdk.Stack {
       envName: props.config.envName,
     });
 
-    new SqsQueue(this, "SqsQueue", {
+    const sqsQueue = new SqsQueue(this, "SqsQueue", {
       envName: props.config.envName,
     });
 
     new DynamoDbTable(this, "DynamoDbTable", {
       envName: props.config.envName,
+    });
+
+    new ApiLambda(this, "ApiLambda", {
+      envName: props.config.envName,
+      queue: sqsQueue.queue,
+      lambdaMemorySize: props.config.lambdaMemorySize,
     });
   }
 }

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -43,6 +43,7 @@ export class RealtimeEventStack extends cdk.Stack {
       envName: props.config.envName,
       queue: sqsQueue.queue,
       lambdaMemorySize: props.config.lambdaMemorySize,
+      artifactsBucketName: props.config.artifactsBucketName,
     });
   }
 }

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -3,6 +3,15 @@
 exports[`snapshot 1`] = `
 {
   "Outputs": {
+    "ApiEndpointUrl": {
+      "Description": "API Gateway HTTP API endpoint URL",
+      "Value": {
+        "Fn::GetAtt": [
+          "ApiLambdaHttpApi7C050CBF",
+          "ApiEndpoint",
+        ],
+      },
+    },
     "AppSyncApiKey": {
       "Description": "AppSync API キー",
       "Value": {
@@ -51,6 +60,195 @@ exports[`snapshot 1`] = `
     },
   },
   "Resources": {
+    "ApiLambdaFunction8FC74655": {
+      "DependsOn": [
+        "ApiLambdaRoleDefaultPolicyABC51E92",
+        "ApiLambdaRole7F72345A",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "SQS_QUEUE_URL": {
+              "Ref": "SqsQueueB359A2D7",
+            },
+          },
+        },
+        "FunctionName": "dev-realtime-event-api",
+        "Handler": "bootstrap",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiLambdaRole7F72345A",
+            "Arn",
+          ],
+        },
+        "Runtime": "provided.al2023",
+        "Timeout": 29,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiLambdaHttpApi7C050CBF": {
+      "Properties": {
+        "Name": "dev-realtime-event-http-api",
+        "ProtocolType": "HTTP",
+      },
+      "Type": "AWS::ApiGatewayV2::Api",
+    },
+    "ApiLambdaHttpApiDefaultRouteD338B959": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "ApiLambdaHttpApi7C050CBF",
+        },
+        "AuthorizationType": "NONE",
+        "RouteKey": "$default",
+        "Target": {
+          "Fn::Join": [
+            "",
+            [
+              "integrations/",
+              {
+                "Ref": "ApiLambdaHttpApiDefaultRouteIntegrationC1482DDF",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Route",
+    },
+    "ApiLambdaHttpApiDefaultRouteIntegrationC1482DDF": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "ApiLambdaHttpApi7C050CBF",
+        },
+        "IntegrationType": "AWS_PROXY",
+        "IntegrationUri": {
+          "Fn::GetAtt": [
+            "ApiLambdaFunction8FC74655",
+            "Arn",
+          ],
+        },
+        "PayloadFormatVersion": "2.0",
+      },
+      "Type": "AWS::ApiGatewayV2::Integration",
+    },
+    "ApiLambdaHttpApiDefaultRouteIntegrationPermission0078E4AC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiLambdaFunction8FC74655",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "ApiLambdaHttpApi7C050CBF",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ApiLambdaHttpApiDefaultStage5899077A": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "ApiLambdaHttpApi7C050CBF",
+        },
+        "AutoDeploy": true,
+        "StageName": "$default",
+      },
+      "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "ApiLambdaRole7F72345A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "RoleName": "dev-realtime-event-api-lambda-role",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiLambdaRoleDefaultPolicyABC51E92": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SqsQueueB359A2D7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiLambdaRoleDefaultPolicyABC51E92",
+        "Roles": [
+          {
+            "Ref": "ApiLambdaRole7F72345A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "AppSyncApiDefaultApiKey4C5F84B8": {
       "DependsOn": [
         "AppSyncApiSchemaD3A1C979",

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -70,10 +70,8 @@ exports[`snapshot 1`] = `
           "arm64",
         ],
         "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "94614a41e469092fa86a2e3b2dc2642a48284c3260a7729aee059fe7c1027a7f.zip",
+          "S3Bucket": "dev-realtime-event-storage",
+          "S3Key": "artifacts/api/bootstrap.zip",
         },
         "Description": "Receives HTTP requests via API Gateway and publishes events to SQS",
         "Environment": {

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -73,8 +73,9 @@ exports[`snapshot 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ebc9d3ac2033816c4abb63e4afd69d350b4aba8704cc9236b82ea520b74f4b0.zip",
+          "S3Key": "94614a41e469092fa86a2e3b2dc2642a48284c3260a7729aee059fe7c1027a7f.zip",
         },
+        "Description": "Receives HTTP requests via API Gateway and publishes events to SQS",
         "Environment": {
           "Variables": {
             "SQS_QUEUE_URL": {
@@ -98,6 +99,7 @@ exports[`snapshot 1`] = `
     },
     "ApiLambdaHttpApi7C050CBF": {
       "Properties": {
+        "Description": "HTTP API for the realtime event delivery platform",
         "Name": "dev-realtime-event-http-api",
         "ProtocolType": "HTTP",
       },

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -68,7 +68,7 @@ exports[`snapshot 1`] = `
     "AppSyncApiEBDAEC17": {
       "Properties": {
         "AuthenticationType": "API_KEY",
-        "Name": "realtime-event-api-dev",
+        "Name": "dev-realtime-event-api",
       },
       "Type": "AWS::AppSync::GraphQLApi",
     },
@@ -119,7 +119,7 @@ schema {
       "Type": "AWS::AppSync::GraphQLSchema",
     },
     "DynamoDbTable6E8DC354": {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Properties": {
         "AttributeDefinitions": [
           {
@@ -134,16 +134,16 @@ schema {
             "KeyType": "HASH",
           },
         ],
-        "TableName": "realtime-event-table-dev",
+        "TableName": "dev-realtime-event-table",
       },
       "Type": "AWS::DynamoDB::Table",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
     },
     "SqsQueueB359A2D7": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "MessageRetentionPeriod": 259200,
-        "QueueName": "realtime-event-queue-dev",
+        "QueueName": "dev-realtime-event-queue",
         "RedrivePolicy": {
           "deadLetterTargetArn": {
             "Fn::GetAtt": [
@@ -162,7 +162,7 @@ schema {
       "DeletionPolicy": "Delete",
       "Properties": {
         "MessageRetentionPeriod": 604800,
-        "QueueName": "realtime-event-dlq-dev",
+        "QueueName": "dev-realtime-event-dlq",
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",


### PR DESCRIPTION
## 概要

Issue #43 の実装。
arm64 / provided.al2023 の Lambda + API Gateway v2 (HTTP API) を `ApiLambda` コンストラクトとして定義し、メインスタックに組み込んだ。

あわせて Issue #41/#42 のブランチで積み残していたリソース名のプレフィックス化、環境切り替え対応、スタック名の PascalCase 化を本 PR に含める。

## 変更内容

- `infra/lib/constructs/api-lambda.ts` (新規) — ApiLambda コンストラクト (Lambda + HTTP API + IAM ロール + SQS SendMessage 権限)
- `infra/lib/stacks/realtime-event-stack.ts` — ApiLambda をメインスタックに組み込み
- `infra/bin/app.ts` — `ENV` 環境変数による dev/prd 切り替え、スタック名を PascalCase (`DevRealtimeEventStack` / `PrdRealtimeEventStack`) に変更
- `infra/config/env-config.ts` — `prdConfig` を追加
- `infra/lib/constructs/{appsync-api,dynamodb-table,sqs-queue}.ts` — リソース名をサフィックス形式 (`xxx-dev`) からプレフィックス形式 (`dev-xxx`) に変更
- `infra/Makefile` — `ENV ?= dev` を追加し synth/diff/deploy/destroy に `ENV=$(ENV)` を渡す
- `backend/Makefile` — ビルド出力を `build/api` (バイナリ) から `build/api/bootstrap` (ディレクトリ内バイナリ) に変更

> [!IMPORTANT]
> CDK の `Code.fromAsset` はディレクトリを zip 化するため、バイナリを直接指定するとエラーになる。
> `backend/build/api/bootstrap` というディレクトリ構成に変更することで解消した。

## 関連 Issue / Discussion

- Closes #43
- Ref #41
- Ref #42

## 動作確認

- [x] `npm test` (スナップショットテスト) が通ることを確認
- [ ] `make deploy` 後に API エンドポイントへアクセスできることを確認 (デプロイ前に `backend/make build` が必要)

## レビュー観点

- Lambda のコードアセットパス (`path.join(__dirname, "../../../backend/build/api")`) が正しくディレクトリを指しているか
- `ENV` 変数なしで `make deploy` したとき dev 環境がデフォルトになるか