### PR TITLE
[infra] [issue-44] [feat] Event Lambda コンストラクト + SQS イベントソース

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -58,16 +58,16 @@ upload-event:
 
 upload: upload-api upload-event
 
-deploy-api:
+deploy-api: upload-api
 	aws lambda update-function-code \
 		--function-name $(ENV)-realtime-event-api \
 		--s3-bucket $(S3_BUCKET) \
 		--s3-key artifacts/api/bootstrap.zip \
-		--profile $(AWS_PROFILE)
+		--profile $(AWS_PROFILE) | jq .
 
-deploy-event:
+deploy-event: upload-event
 	aws lambda update-function-code \
 		--function-name $(ENV)-realtime-event-event \
 		--s3-bucket $(S3_BUCKET) \
 		--s3-key artifacts/event/bootstrap.zip \
-		--profile $(AWS_PROFILE)
+		--profile $(AWS_PROFILE) | jq .

--- a/backend/internal/handler/api/handler.go
+++ b/backend/internal/handler/api/handler.go
@@ -37,6 +37,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var payloadMap map[string]interface{}
+	if err := json.Unmarshal(req.Payload, &payloadMap); err != nil || len(payloadMap) == 0 {
+		writeJSONError(w, "payload must not be empty", http.StatusBadRequest)
+		return
+	}
+
 	body, err := json.Marshal(req)
 	if err != nil {
 		writeJSONError(w, "failed to marshal request", http.StatusInternalServerError)

--- a/backend/internal/handler/api/handler_test.go
+++ b/backend/internal/handler/api/handler_test.go
@@ -28,7 +28,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		wantStatus  int
 	}{
 		"正常系_有効なリクエスト": {
-			body:       `{"event_type":"test","payload":{}}`,
+			body:       `{"event_type":"test","payload":{"key":"value"}}`,
 			wantStatus: http.StatusAccepted,
 		},
 		"正常系_payload_にデータを含む": {
@@ -50,8 +50,18 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 			wantError:  "event_type is required",
 		},
+		"異常系_payload_が空": {
+			body:       `{"event_type":"test","payload":{}}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "payload must not be empty",
+		},
+		"異常系_payload_が欠落": {
+			body:       `{"event_type":"test"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "payload must not be empty",
+		},
 		"異常系_SQS_送信エラー": {
-			body:        `{"event_type":"test","payload":{}}`,
+			body:        `{"event_type":"test","payload":{"key":"value"}}`,
 			producerErr: errors.New("sqs error"),
 			wantStatus:  http.StatusInternalServerError,
 			wantError:   "failed to send message",

--- a/backend/tools/httprequest/dev/post_events.http
+++ b/backend/tools/httprequest/dev/post_events.http
@@ -7,7 +7,9 @@ Content-Type: application/json
 
 {
   "event_type": "test",
-  "payload": {}
+  "payload": {
+    "message": "test"
+  }
 }
 
 ###

--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -93,11 +93,9 @@ export class ApiLambda extends Construct {
     });
 
     // cdk.json の useCdkManagedLogGroup が自動生成したロググループに保持期間 7 日とスタック削除ポリシーを設定する
-    // 既存スタックに自動生成済みのロググループがある場合、logGroup プロパティで新規作成すると同名リソースの衝突が起きるためこの方式を採用
-    // this.fn.logGroup は feature flag が無効な環境では fromLogGroupName() のインポート参照を返し defaultChild が存在しないため node.findChild で取得する
     const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
     (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
-    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
 
     // Lambda の IAM Role に SQS SendMessage 権限を付与
     props.queue.grantSendMessages(this.fn);

--- a/infra/lib/constructs/event-lambda.ts
+++ b/infra/lib/constructs/event-lambda.ts
@@ -84,7 +84,7 @@ export class EventLambda extends Construct {
     // cdk.json の useCdkManagedLogGroup が自動生成したロググループに保持期間 7 日とスタック削除ポリシーを設定する
     const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
     (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
-    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
 
     // DynamoDB テーブルへの書き込み権限を付与
     props.table.grantWriteData(this.fn);

--- a/infra/lib/constructs/event-lambda.ts
+++ b/infra/lib/constructs/event-lambda.ts
@@ -75,6 +75,8 @@ export class EventLambda extends Construct {
       // SQS の可視性タイムアウト (30 秒) を超えないよう 25 秒に設定する
       timeout: cdk.Duration.seconds(25),
       environment: {
+        APP_ENV: props.envName,
+        EVENT_SERVICE_NAME: `${props.envName}-realtime-event-event`,
         APPSYNC_API_KEY: props.appSyncApiKey,
         APPSYNC_ENDPOINT: props.appSyncUrl,
         DYNAMODB_TABLE_NAME: props.table.tableName,

--- a/infra/lib/constructs/event-lambda.ts
+++ b/infra/lib/constructs/event-lambda.ts
@@ -1,0 +1,99 @@
+import * as cdk from "aws-cdk-lib";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambda_event_sources from "aws-cdk-lib/aws-lambda-event-sources";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+
+/**
+ * EventLambda コンストラクタプロパティ
+ *
+ * @property envName - 環境名。リソースの命名に使用する
+ * @property queue - SQS メインキュー。イベントソースとして設定する
+ * @property table - DynamoDB イベントテーブル。書き込み権限を付与する
+ * @property appSyncUrl - AppSync GraphQL エンドポイント URL
+ * @property appSyncApiKey - AppSync API キー
+ * @property lambdaMemorySize - Lambda 関数のメモリサイズ (MB)
+ * @property artifactsBucketName - Lambda ビルド成果物を格納する S3 バケット名
+ */
+interface EventLambdaProps {
+  readonly envName: string;
+  readonly queue: sqs.Queue;
+  readonly table: dynamodb.Table;
+  readonly appSyncUrl: string;
+  readonly appSyncApiKey: string;
+  readonly lambdaMemorySize: number;
+  readonly artifactsBucketName: string;
+}
+
+/**
+ * Event Lambda コンストラクト
+ *
+ * arm64 / provided.al2023 で Lambda を定義し、SQS メインキューをイベントソースとして設定する。
+ * パーシャルバッチ失敗対応のため reportBatchItemFailures を有効化する。
+ */
+export class EventLambda extends Construct {
+  /** Event Lambda 関数 */
+  readonly fn: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: EventLambdaProps) {
+    super(scope, id);
+
+    // Lambda Execution Role
+    const role = new iam.Role(this, "Role", {
+      roleName: `${props.envName}-realtime-event-event-lambda-role`,
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      // ref: https://docs.aws.amazon.com/ja_jp/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaBasicExecutionRole",
+        ),
+      ],
+    });
+
+    this.fn = new lambda.Function(this, "Function", {
+      functionName: `${props.envName}-realtime-event-event`,
+      description:
+        "Consumes SQS events, writes to DynamoDB, and publishes to AppSync",
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      architecture: lambda.Architecture.ARM_64,
+      handler: "bootstrap",
+      // make upload-event で s3://{artifactsBucketName}/artifacts/event/bootstrap.zip にアップロードされたバイナリを参照する
+      code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(
+          this,
+          "ArtifactsBucket",
+          props.artifactsBucketName,
+        ),
+        "artifacts/event/bootstrap.zip",
+      ),
+      role,
+      memorySize: props.lambdaMemorySize,
+      // SQS の可視性タイムアウト (30 秒) を超えないよう 25 秒に設定する
+      timeout: cdk.Duration.seconds(25),
+      environment: {
+        APPSYNC_API_KEY: props.appSyncApiKey,
+        APPSYNC_ENDPOINT: props.appSyncUrl,
+        DYNAMODB_TABLE_NAME: props.table.tableName,
+      },
+    });
+
+    // cdk.json の useCdkManagedLogGroup が自動生成したロググループに保持期間 7 日とスタック削除ポリシーを設定する
+    const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
+    (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+
+    // DynamoDB テーブルへの書き込み権限を付与
+    props.table.grantWriteData(this.fn);
+
+    // SQS メインキューをイベントソースとして設定し、パーシャルバッチ失敗を有効化する
+    this.fn.addEventSource(
+      new lambda_event_sources.SqsEventSource(props.queue, {
+        reportBatchItemFailures: true,
+      }),
+    );
+  }
+}

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -5,6 +5,7 @@ import { EnvConfig } from "../../config/env-config";
 import { ApiLambda } from "../constructs/api-lambda";
 import { AppSyncApi } from "../constructs/appsync-api";
 import { DynamoDbTable } from "../constructs/dynamodb-table";
+import { EventLambda } from "../constructs/event-lambda";
 import { SqsQueue } from "../constructs/sqs-queue";
 
 /**
@@ -27,7 +28,7 @@ export class RealtimeEventStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: RealtimeEventStackProps) {
     super(scope, id, props);
 
-    new AppSyncApi(this, "AppSyncApi", {
+    const appSyncApi = new AppSyncApi(this, "AppSyncApi", {
       envName: props.config.envName,
     });
 
@@ -35,13 +36,23 @@ export class RealtimeEventStack extends cdk.Stack {
       envName: props.config.envName,
     });
 
-    new DynamoDbTable(this, "DynamoDbTable", {
+    const dynamoDbTable = new DynamoDbTable(this, "DynamoDbTable", {
       envName: props.config.envName,
     });
 
     new ApiLambda(this, "ApiLambda", {
       envName: props.config.envName,
       queue: sqsQueue.queue,
+      lambdaMemorySize: props.config.lambdaMemorySize,
+      artifactsBucketName: props.config.artifactsBucketName,
+    });
+
+    new EventLambda(this, "EventLambda", {
+      envName: props.config.envName,
+      queue: sqsQueue.queue,
+      table: dynamoDbTable.table,
+      appSyncUrl: appSyncApi.api.graphqlUrl,
+      appSyncApiKey: appSyncApi.api.apiKey ?? "",
       lambdaMemorySize: props.config.lambdaMemorySize,
       artifactsBucketName: props.config.artifactsBucketName,
     });

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -431,9 +431,11 @@ schema {
                 "GraphQLUrl",
               ],
             },
+            "APP_ENV": "dev",
             "DYNAMODB_TABLE_NAME": {
               "Ref": "DynamoDbTable6E8DC354",
             },
+            "EVENT_SERVICE_NAME": "dev-realtime-event-event",
           },
         },
         "FunctionName": "dev-realtime-event-event",

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -403,6 +403,171 @@ schema {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
     },
+    "EventLambdaFunction39988493": {
+      "DependsOn": [
+        "EventLambdaRoleDefaultPolicy20B3E462",
+        "EventLambdaRole47425437",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": "dev-realtime-event-storage",
+          "S3Key": "artifacts/event/bootstrap.zip",
+        },
+        "Description": "Consumes SQS events, writes to DynamoDB, and publishes to AppSync",
+        "Environment": {
+          "Variables": {
+            "APPSYNC_API_KEY": {
+              "Fn::GetAtt": [
+                "AppSyncApiDefaultApiKey4C5F84B8",
+                "ApiKey",
+              ],
+            },
+            "APPSYNC_ENDPOINT": {
+              "Fn::GetAtt": [
+                "AppSyncApiEBDAEC17",
+                "GraphQLUrl",
+              ],
+            },
+            "DYNAMODB_TABLE_NAME": {
+              "Ref": "DynamoDbTable6E8DC354",
+            },
+          },
+        },
+        "FunctionName": "dev-realtime-event-event",
+        "Handler": "bootstrap",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "EventLambdaRole47425437",
+            "Arn",
+          ],
+        },
+        "Runtime": "provided.al2023",
+        "Timeout": 25,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "EventLambdaFunctionLogGroup837239B8": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "EventLambdaFunction39988493",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EventLambdaFunctionSqsEventSourceTestStackSqsQueue62C47C6C9F949501": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "SqsQueueB359A2D7",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "EventLambdaFunction39988493",
+        },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "EventLambdaRole47425437": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "RoleName": "dev-realtime-event-event-lambda-role",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EventLambdaRoleDefaultPolicy20B3E462": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "DynamoDbTable6E8DC354",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SqsQueueB359A2D7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EventLambdaRoleDefaultPolicy20B3E462",
+        "Roles": [
+          {
+            "Ref": "EventLambdaRole47425437",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SqsQueueB359A2D7": {
       "DeletionPolicy": "Delete",
       "Properties": {


### PR DESCRIPTION
## 概要

Issue #44 の実装として、SQS メインキューをトリガーとする Event Lambda コンストラクトを追加した。
パーシャルバッチ失敗に対応するため `reportBatchItemFailures: true` を設定し、DynamoDB 書き込み権限と AppSync 接続情報を環境変数として渡す。

## 変更内容

- `event-lambda.ts` (新規): EventLambda L3 コンストラクトを実装
  - `reportBatchItemFailures: true` で SQS イベントソースを設定
  - 環境変数: `APPSYNC_API_KEY` / `APPSYNC_ENDPOINT` / `DYNAMODB_TABLE_NAME`
  - DynamoDB テーブルへの書き込み権限 (`grantWriteData`) を付与
  - CDK 管理ロググループに保持期間 7 日・DESTROY ポリシーを設定
- `realtime-event-stack.ts`: AppSyncApi / DynamoDbTable の参照を保持し、EventLambda を組み込む
- スナップショットテストを更新

## 関連 Issue

- Closes #44

## 動作確認

- [x] `npx tsc` でコンパイル通過
- [x] `npm test` でスナップショットテスト通過

## レビュー観点

> [!NOTE]
> **`reportBatchItemFailures` の型について**
> Issue には `ReportBatchItemFailures.REPORT_ALL` と記載があるが、この CDK バージョン (`aws-cdk-lib@2.257.0`) では `SqsEventSourceProps.reportBatchItemFailures` は `boolean` 型として定義されている。
> `true` を設定することで同等の挙動 (失敗したアイテムのみ DLQ へ) を実現する。