### PR TITLE
[infra] [issue-46] [feat] CloudFront + S3 バケット定義

### DIFF
--- a/infra/lib/constructs/api-lambda.ts
+++ b/infra/lib/constructs/api-lambda.ts
@@ -95,7 +95,7 @@ export class ApiLambda extends Construct {
     // cdk.json の useCdkManagedLogGroup が自動生成したロググループに保持期間 7 日とスタック削除ポリシーを設定する
     const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
     (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
-    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にログも削除する (本番運用時は RETAIN 推奨)
 
     // Lambda の IAM Role に SQS SendMessage 権限を付与
     props.queue.grantSendMessages(this.fn);

--- a/infra/lib/constructs/cloudfront-s3.ts
+++ b/infra/lib/constructs/cloudfront-s3.ts
@@ -1,0 +1,70 @@
+import * as cdk from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as cloudfront_origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+
+/**
+ * CloudFrontS3 コンストラクタプロパティ
+ *
+ * @property envName - 環境名。リソースの命名に使用する
+ */
+interface CloudFrontS3Props {
+  readonly envName: string;
+}
+
+/**
+ * フロントエンド SPA 配信用 S3 + CloudFront コンストラクト
+ *
+ * S3 はパブリックアクセスを完全ブロックし、OAC で CloudFront のみアクセスを許可する。
+ * SPA ルーティング用に 403 を /index.html (200) へリダイレクトする。
+ */
+export class CloudFrontS3 extends Construct {
+  /** フロントエンド SPA 用 S3 バケット */
+  readonly bucket: s3.Bucket;
+
+  /** CloudFront ディストリビューション */
+  readonly distribution: cloudfront.Distribution;
+
+  // コンストラクタ
+  constructor(scope: Construct, id: string, props: CloudFrontS3Props) {
+    super(scope, id);
+
+    // S3 バケットを作成 (パブリックアクセスはブロック)
+    this.bucket = new s3.Bucket(this, "Bucket", {
+      bucketName: `${props.envName}-realtime-event-frontend`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // スタック削除時にバケットも削除 (本番運用時は RETAIN 推奨)
+      autoDeleteObjects: true,
+    });
+
+    // CloudFront ディストリビューションを作成 (OAC で S3 バケットにアクセス)
+    this.distribution = new cloudfront.Distribution(this, "Distribution", {
+      // S3 バケットをオリジンに設定 (OAC 経由)
+      defaultBehavior: {
+        origin: cloudfront_origins.S3BucketOrigin.withOriginAccessControl(
+          this.bucket,
+        ),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS, // HTTP を HTTPS にリダイレクト
+      },
+
+      // SPA ルーティング用に 403 を /index.html (200) へリダイレクト
+      defaultRootObject: "index.html",
+
+      // 403 エラーをキャッチして /index.html にリダイレクト (SPA ルーティング対応)
+      errorResponses: [
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: "/index.html",
+        },
+      ],
+    });
+
+    // CloudFront のディストリビューションドメインを Stack Output に出力
+    new cdk.CfnOutput(scope, "CloudFrontUrl", {
+      value: `https://${this.distribution.distributionDomainName}`,
+      description: "CloudFront distribution URL",
+    });
+  }
+}

--- a/infra/lib/constructs/event-lambda.ts
+++ b/infra/lib/constructs/event-lambda.ts
@@ -87,7 +87,7 @@ export class EventLambda extends Construct {
     // cdk.json の useCdkManagedLogGroup が自動生成したロググループに保持期間 7 日とスタック削除ポリシーを設定する
     const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
     (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
-    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY); // スタック削除時にログも削除する (本番運用時は RETAIN 推奨)
 
     // DynamoDB テーブルへの書き込み権限を付与
     props.table.grantWriteData(this.fn);

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -4,6 +4,7 @@ import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
 import { ApiLambda } from "../constructs/api-lambda";
 import { AppSyncApi } from "../constructs/appsync-api";
+import { CloudFrontS3 } from "../constructs/cloudfront-s3";
 import { DynamoDbTable } from "../constructs/dynamodb-table";
 import { EventLambda } from "../constructs/event-lambda";
 import { SqsQueue } from "../constructs/sqs-queue";
@@ -20,7 +21,6 @@ interface RealtimeEventStackProps extends cdk.StackProps {
 /**
  * リアルタイムイベント配信プラットフォームのメインスタック
  *
- * PoC フェーズは単一スタックで全リソースを管理する。
  * 本番移行時に stateful (DynamoDB / SQS) と stateless (Lambda / AppSync) に分割する。
  * 各リソースは lib/constructs/ 配下の L3 カスタムコンストラクトに分割して組み立てる。
  */
@@ -56,6 +56,10 @@ export class RealtimeEventStack extends cdk.Stack {
       appSyncApiKey: appSyncApi.api.apiKey ?? "",
       lambdaMemorySize: props.config.lambdaMemorySize,
       artifactsBucketName: props.config.artifactsBucketName,
+    });
+
+    new CloudFrontS3(this, "CloudFrontS3", {
+      envName: props.config.envName,
     });
   }
 }

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -30,6 +30,23 @@ exports[`snapshot 1`] = `
         ],
       },
     },
+    "CloudFrontUrl": {
+      "Description": "CloudFront distribution URL",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Fn::GetAtt": [
+                "CloudFrontS3Distribution33D25935",
+                "DomainName",
+              ],
+            },
+          ],
+        ],
+      },
+    },
     "DynamoDbTableName": {
       "Description": "DynamoDB event table name",
       "Value": {
@@ -381,6 +398,254 @@ schema {
 ",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
+    },
+    "CloudFrontS3Bucket73FAB78F": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "BucketName": "dev-realtime-event-frontend",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CloudFrontS3BucketAutoDeleteObjectsCustomResource153647A9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "CloudFrontS3BucketPolicy54FF1FF0",
+      ],
+      "Properties": {
+        "BucketName": {
+          "Ref": "CloudFrontS3Bucket73FAB78F",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CloudFrontS3BucketPolicy54FF1FF0": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "CloudFrontS3Bucket73FAB78F",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "CloudFrontS3Bucket73FAB78F",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "CloudFrontS3Bucket73FAB78F",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "s3:GetObject",
+              "Condition": {
+                "StringEquals": {
+                  "AWS:SourceArn": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":cloudfront::",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":distribution/",
+                        {
+                          "Ref": "CloudFrontS3Distribution33D25935",
+                        },
+                      ],
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "cloudfront.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "CloudFrontS3Bucket73FAB78F",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "CloudFrontS3Distribution33D25935": {
+      "Properties": {
+        "DistributionConfig": {
+          "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "TestStackCloudFrontS3DistributionOrigin1034CEE19",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": [
+            {
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "CloudFrontS3Bucket73FAB78F",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "TestStackCloudFrontS3DistributionOrigin1034CEE19",
+              "OriginAccessControlId": {
+                "Fn::GetAtt": [
+                  "CloudFrontS3DistributionOrigin1S3OriginAccessControlEC9108D6",
+                  "Id",
+                ],
+              },
+              "S3OriginConfig": {
+                "OriginAccessIdentity": "",
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "CloudFrontS3DistributionOrigin1S3OriginAccessControlEC9108D6": {
+      "Properties": {
+        "OriginAccessControlConfig": {
+          "Name": "TestStackCloudFrontS3DistribOrigin1S3OriginAccessControlEC135EE4",
+          "OriginAccessControlOriginType": "s3",
+          "SigningBehavior": "always",
+          "SigningProtocol": "sigv4",
+        },
+      },
+      "Type": "AWS::CloudFront::OriginAccessControl",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
+      "DependsOn": [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+        },
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Lambda function for auto-deleting objects in ",
+              {
+                "Ref": "CloudFrontS3Bucket73FAB78F",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "DynamoDbTable6E8DC354": {
       "DeletionPolicy": "Delete",


### PR DESCRIPTION
## Why

フロントエンド SPA の静的ファイルを配信するための S3 + CloudFront 構成が未定義だった。

## What

- `CloudFrontS3` コンストラクトを `infra/lib/constructs/cloudfront-s3.ts` に新規追加した
- S3 バケットはパブリックアクセスを完全ブロックし、OAC で CloudFront のみからのアクセスを許可した
- 403 エラーを `/index.html` (200) へリダイレクトし、SPA のディープリンクに対応した
- `defaultRootObject: "index.html"` を設定した
- CloudFront URL を Stack Output に出力した

## How

CDK の `S3BucketOrigin.withOriginAccessControl()` を使用することで、OAC の作成・バケットポリシーへの紐付けを自動化した。
S3 バケットへの直接アクセスは OAC の条件付きポリシー (`AWS:SourceArn` で特定 Distribution に限定) により拒否される。

## Note

- `removalPolicy: DESTROY` / `autoDeleteObjects: true` は PoC 用。本番運用時は `RETAIN` 推奨
- prd deploy 済み・動作確認は Issue #46 のコメントを参照