### PR TITLE
[frontend] [issue-23] [feat] Zustand ストア定義

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "aws-amplify": "^6.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "tailwindcss": "^4.3.0"
+        "tailwindcss": "^4.3.0",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2170,7 +2171,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2687,7 +2688,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4337,6 +4338,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "aws-amplify": "^6.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "tailwindcss": "^4.3.0"
+    "tailwindcss": "^4.3.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/features/event-feed/model/store.ts
+++ b/frontend/src/features/event-feed/model/store.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+
+/**
+ * イベントフィードの 1 件分のデータ型
+ *
+ * @property event_id - イベントの一意識別子
+ * @property event_type - イベントの種別
+ * @property payload - イベントペイロード (JSON 文字列)
+ * @property created_at - イベントの作成日時 (Unix タイムスタンプ, 秒)
+ */
+export interface EventItem {
+  event_id: string;
+  event_type: string;
+  payload: string;
+  created_at: number;
+}
+
+/**
+ * イベントフィードストアの state とアクションの定義
+ *
+ * @property events - 受信済みイベントの一覧 (新着順)
+ * @property addEvent - イベントをリスト先頭に追加する
+ * @property clearEvents - イベントリストをリセットする
+ */
+interface EventFeedState {
+  events: EventItem[];
+  addEvent: (item: EventItem) => void;
+  clearEvents: () => void;
+}
+
+/**
+ * イベントフィード Zustand ストア
+ *
+ * AppSync Subscription で受信したイベントをリアクティブに管理する。
+ * addEvent で先頭追加、clearEvents で全件クリアを行う。
+ */
+export const useEventFeedStore = create<EventFeedState>((set) => ({
+  events: [],
+  addEvent: (item) => set((state) => ({ events: [item, ...state.events] })),
+  clearEvents: () => set({ events: [] }),
+}));


### PR DESCRIPTION
## Why

AppSync Subscription で受信したイベントをコンポーネントがリアクティブに参照できる状態管理基盤が必要なため、Zustand ストアを定義した。

## What

- `features/event-feed/model/store.ts` に `useEventFeedStore` を実装
- `EventItem` 型 (`event_id`, `event_type`, `payload: string`, `created_at: number`) を定義
- `addEvent` (先頭追加) / `clearEvents` (全件クリア) アクションを実装

## Notes

> [!NOTE]
> `payload` は GraphQL スキーマが `String!` のため JSON 文字列として定義。
> `created_at` は `AWSTimestamp!` (Unix タイムスタンプ, 秒) のため `number` 型。

Closes #23