### PR TITLE
[frontend] [issue-24] [feat] イベント送信フォーム実装

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,6 @@ VITE_APPSYNC_API_KEY=da2-xxxxxxxxxxxxxxxxxxxx
 
 # AWS region
 VITE_AWS_REGION=ap-northeast-1
+
+# Backend API base URL
+VITE_API_BASE_URL=https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com

--- a/frontend/src/features/event-sender/api/index.ts
+++ b/frontend/src/features/event-sender/api/index.ts
@@ -1,1 +1,17 @@
-export {};
+import { post } from "@shared/api/http";
+
+/**
+ * POST /events のリクエスト型
+ *
+ * @property event_type - イベントの種別
+ * @property payload - イベントペイロード (JSON オブジェクト)
+ */
+interface PostEventsRequest {
+  event_type: string;
+  payload: Record<string, unknown>;
+}
+
+/** POST /events — イベントを API Lambda に送信する */
+export async function postEvents(req: PostEventsRequest): Promise<void> {
+  await post<void>("/events", req);
+}

--- a/frontend/src/features/event-sender/ui/EventSenderForm.tsx
+++ b/frontend/src/features/event-sender/ui/EventSenderForm.tsx
@@ -1,3 +1,71 @@
+import React, { useState } from "react";
+
+import { postEvents } from "../api";
+
+/**
+ * イベント送信フォームコンポーネント
+ *
+ * event_type と payload (JSON) を入力して POST /events を呼び出す。
+ * 送信中はボタンを disabled にしてローディングを表示し、
+ * エラー時にはメッセージを表示する。送信成功時にフォームをリセットする。
+ */
 export function EventSenderForm() {
-  return <div>EventSenderForm</div>;
+  const [eventType, setEventType] = useState("");
+  const [payloadStr, setPayloadStr] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(payloadStr) as Record<string, unknown>;
+    } catch {
+      setError("payload は有効な JSON 形式で入力してください");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await postEvents({ event_type: eventType, payload });
+      setEventType("");
+      setPayloadStr("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "送信に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="event-type">event_type</label>
+        <input
+          id="event-type"
+          type="text"
+          value={eventType}
+          onChange={(e) => setEventType(e.target.value)}
+          required
+          disabled={loading}
+        />
+      </div>
+      <div>
+        <label htmlFor="payload">payload (JSON)</label>
+        <textarea
+          id="payload"
+          value={payloadStr}
+          onChange={(e) => setPayloadStr(e.target.value)}
+          required
+          disabled={loading}
+        />
+      </div>
+      {error && <p role="alert">{error}</p>}
+      <button type="submit" disabled={loading}>
+        {loading ? "送信中..." : "送信"}
+      </button>
+    </form>
+  );
 }

--- a/frontend/src/shared/api/http.ts
+++ b/frontend/src/shared/api/http.ts
@@ -1,11 +1,24 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 
+/**
+ * GET リクエストを送信する
+ *
+ * @param path - ベース URL に結合するパス (例: `/events`)
+ * @returns レスポンスを T 型にパースした値
+ */
 export async function get<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<T>;
 }
 
+/**
+ * JSON ボディで POST リクエストを送信する
+ *
+ * @param path - ベース URL に結合するパス (例: `/events`)
+ * @param body - リクエストボディ。JSON シリアライズして送信する
+ * @returns レスポンスを T 型にパースした値。ボディなし (202 等) の場合は undefined
+ */
 export async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`, {
     method: "POST",
@@ -13,5 +26,6 @@ export async function post<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<T>;
+  const text = await res.text();
+  return (text ? JSON.parse(text) : undefined) as T;
 }


### PR DESCRIPTION
## Why

フロントエンドから `POST /events` を呼び出す手段が存在しなかったため、イベント送信フォームとその依存ロジックを整備した。

## What

- `features/event-sender/api/index.ts` — `postEvents()` 関数を実装 (`POST /events` 呼び出し)
- `features/event-sender/ui/EventSenderForm.tsx` — event_type・payload 入力フォームを実装
- `shared/api/http.ts` — `post<T>()` を 202 等の空レスポンスに対応させ、JSDoc を追加
- `.env.example` — `VITE_API_BASE_URL` を追記

## Notes

> [!NOTE]
> `EventSenderForm` はまだどのページにも配置していない。
> 画面への組み込みは後続 Issue で対応する。

> [!NOTE]
> `React.FormEvent` は React 19 で非推奨。`React.SubmitEvent<HTMLFormElement>` を使用している。

Closes #24