### PR TITLE
[frontend] [issue-25] [feat] AppSync Subscription 接続 + リアルタイム受信 UI

### DIFF
--- a/frontend/src/features/event-feed/api/index.ts
+++ b/frontend/src/features/event-feed/api/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { useEventSubscription } from "./useEventSubscription";

--- a/frontend/src/features/event-feed/api/useEventSubscription.ts
+++ b/frontend/src/features/event-feed/api/useEventSubscription.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { appSyncClient } from "@shared/api/appsync";
 
-import { type EventItem, useEventFeedStore } from "../model/store";
+import { type EventItem, useEventFeedStore } from "@features/event-feed/model/store";
 
 const ON_EVENT_RECEIVED = /* GraphQL */ `
   subscription OnEventReceived {

--- a/frontend/src/features/event-feed/api/useEventSubscription.ts
+++ b/frontend/src/features/event-feed/api/useEventSubscription.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+import { appSyncClient } from "@shared/api/appsync";
+
+import { type EventItem, useEventFeedStore } from "../model/store";
+
+const ON_EVENT_RECEIVED = /* GraphQL */ `
+  subscription OnEventReceived {
+    onEventReceived {
+      event_id
+      event_type
+      payload
+      created_at
+    }
+  }
+`;
+
+/** AppSync Subscription のレスポンス型 */
+interface SubscriptionResponse {
+  data: { onEventReceived: EventItem | null };
+}
+
+/** graphql() が Subscription のとき返す Observable 互換の型 */
+interface SubscriptionObservable {
+  subscribe(handlers: {
+    next: (value: SubscriptionResponse) => void;
+    error: (error: unknown) => void;
+  }): { unsubscribe(): void };
+}
+
+/**
+ * AppSync onEventReceived Subscription カスタムフック
+ *
+ * マウント時に Subscription を開始し、受信イベントを useEventFeedStore に追加する。
+ * アンマウント時に自動で unsubscribe する。
+ *
+ * @returns error - 接続エラーメッセージ。正常時は null
+ */
+export function useEventSubscription(): { error: string | null } {
+  const addEvent = useEventFeedStore((s) => s.addEvent);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const observable = appSyncClient.graphql({
+      query: ON_EVENT_RECEIVED,
+    }) as unknown as SubscriptionObservable;
+
+    const sub = observable.subscribe({
+      next: ({ data }) => {
+        const item = data?.onEventReceived;
+        if (item) addEvent(item);
+      },
+      error: (err) => {
+        setError(err instanceof Error ? err.message : "Subscription 接続に失敗しました");
+      },
+    });
+
+    return () => sub.unsubscribe();
+  }, [addEvent]);
+
+  return { error };
+}

--- a/frontend/src/features/event-feed/ui/EventFeed.tsx
+++ b/frontend/src/features/event-feed/ui/EventFeed.tsx
@@ -1,3 +1,34 @@
+import { useEventSubscription } from "../api";
+import { useEventFeedStore } from "../model/store";
+
+/**
+ * リアルタイムイベントフィードコンポーネント
+ *
+ * AppSync Subscription で受信したイベントをリスト表示する。
+ * マウント時に Subscription を開始し、アンマウント時に切断する。
+ * 接続エラー時はフォールバックメッセージを表示する。
+ */
 export function EventFeed() {
-  return <div>EventFeed</div>;
+  const events = useEventFeedStore((s) => s.events);
+  const { error } = useEventSubscription();
+
+  if (error) {
+    return <p role="alert">Subscription エラー: {error}</p>;
+  }
+
+  return (
+    <ul>
+      {events.length === 0 ? (
+        <li>イベントを待機中...</li>
+      ) : (
+        events.map((event) => (
+          <li key={event.event_id}>
+            <strong>{event.event_type}</strong>
+            <span>{new Date(event.created_at * 1000).toLocaleString()}</span>
+            <pre>{event.payload}</pre>
+          </li>
+        ))
+      )}
+    </ul>
+  );
 }

--- a/frontend/src/features/event-feed/ui/EventFeed.tsx
+++ b/frontend/src/features/event-feed/ui/EventFeed.tsx
@@ -1,5 +1,5 @@
-import { useEventSubscription } from "../api";
-import { useEventFeedStore } from "../model/store";
+import { useEventSubscription } from "@features/event-feed/api";
+import { useEventFeedStore } from "@features/event-feed/model/store";
 
 /**
  * リアルタイムイベントフィードコンポーネント

--- a/frontend/src/features/event-sender/ui/EventSenderForm.tsx
+++ b/frontend/src/features/event-sender/ui/EventSenderForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { postEvents } from "../api";
+import { postEvents } from "@features/event-sender/api";
 
 /**
  * イベント送信フォームコンポーネント


### PR DESCRIPTION
## Why

AppSync Subscription に接続してリアルタイムにイベントを受信・表示する基盤が必要なため、Subscription フックと表示コンポーネントを実装した。

## What

- `features/event-feed/api/useEventSubscription.ts` — `onEventReceived` を subscribe するカスタムフック
  - 受信イベントを `useEventFeedStore().addEvent()` でストアに追加
  - `useEffect` クリーンアップで `unsubscribe()` を呼び切断を保証
- `features/event-feed/ui/EventFeed.tsx` — イベントリストの表示コンポーネント
  - Subscription エラー時はフォールバックメッセージを表示
  - 待機中・受信済みで表示を切り替え

## Notes

> [!NOTE]
> `appSyncClient.graphql()` の戻り値は Query/Mutation (Promise) と Subscription (Observable) で型が異なるため、Subscription 側は `SubscriptionObservable` インターフェースを定義して型キャストしている。

> [!NOTE]
> `EventFeed` はまだどのページにも配置していない。画面への組み込みは後続 Issue で対応する。

Closes #25