### PR TITLE
[frontend] [issue-26] [feat] CloudFront + S3 静的配信設定

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,11 @@
+# AppSync GraphQL endpoint URL
+VITE_APPSYNC_URL=https://xxxxxxxxxx.appsync-api.ap-northeast-1.amazonaws.com/graphql
+
+# AppSync API key
+VITE_APPSYNC_API_KEY=da2-xxxxxxxxxxxxxxxxxxxx
+
+# AWS region
+VITE_AWS_REGION=ap-northeast-1
+
+# Backend API base URL (local dev)
+VITE_API_BASE_URL=http://localhost:18080

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,7 +12,7 @@ dist
 dist-ssr
 *.local
 .vite
-.env
+.env.production
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Why

本番ビルドを S3 + CloudFront で配信するための環境変数ファイルが未整備だったため、本番用・ローカル開発用の env ファイルを整備した。

## What

- `.gitignore` に `.env.production` を追加 — シークレットの誤コミットを防ぐ
- `.env.development` を追加 — `VITE_API_BASE_URL=http://localhost:18080` を設定し git 管理下に置く

## Notes

> [!NOTE]
> `.env.production` はローカルにのみ存在し git 管理外。
> 値は CloudFormation Stack Outputs (`PrdRealtimeEventStack`) から取得する。

> [!NOTE]
> S3 アップロードと CloudFront 動作確認は手動手順のため PR には含まない。
> `make upload AWS_PROFILE=<profile>` → `make deploy AWS_PROFILE=<profile> CF_DISTRIBUTION_ID=<id>` で実行する。

Closes #26