### PR TITLE
[frontend] [issue-107] [feat] テナント別チャンネル購読

### DIFF
--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -1,0 +1,13 @@
+/**
+ * アプリケーション固有の設定
+ *
+ * amplify.ts で管理する Cognito・AppSync 設定を除いた、アプリ固有の環境変数を集約する。
+ * import.meta.env への直接アクセスはこのファイルのみに限定する。
+ *
+ * @property appEnv - 実行環境 ("local" | "prd")
+ * @property apiBaseUrl - バックエンド API のベース URL
+ */
+export const config = {
+  appEnv: import.meta.env.VITE_APP_ENV as "local" | "prd",
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL ?? "",
+} as const;

--- a/frontend/src/features/event-feed/api/useEventSubscription.ts
+++ b/frontend/src/features/event-feed/api/useEventSubscription.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import type { EventsChannel } from "aws-amplify/api";
 
+import { config } from "@app/config";
 import { events } from "@shared/api/appsync";
+import { useAuthStore } from "@features/auth/model/store";
 import { buildEventItem } from "@features/event-feed/model/buildEventItem";
 import type { EventItem } from "@features/event-feed/model/store";
 import { useEventFeedStore } from "@features/event-feed/model/store";
@@ -27,26 +29,41 @@ interface ReceivedEvent {
 /**
  * AppSync Events WebSocket サブスクリプション カスタムフック
  *
- * マウント時に `tickets/orders` チャンネルへ接続し、受信イベントを useEventFeedStore に追加する。
- * アンマウント時に自動でチャンネルを close する。
+ * サインイン後に `tickets/orders/{tenantId}/{userId}` チャンネルへ接続し、
+ * 受信イベントを useEventFeedStore に追加する。
+ * tenantId・userId のどちらかが null の場合は接続しない。
+ * サインアウト時は clearAuth() により両値が null になり、useEffect のクリーンアップで自動切断する。
  * VITE_APP_ENV が "local" のときは接続しない。イベント追加は postTicketOrder が直接行う。
  *
  * @returns error - 接続エラーメッセージ。正常時は null
  */
 export function useEventSubscription(): { error: string | null } {
+  // 受信イベントをストアに追加するコールバック
   const addEvent = useEventFeedStore((s) => s.addEvent);
+
+  // テナント別チャンネルパスの構築に使用する。管理者が付与するまで tenantId は null になる
+  const tenantId = useAuthStore((s) => s.tenantId);
+  const userId = useAuthStore((s) => s.userId);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    switch (import.meta.env.VITE_APP_ENV) {
+    // tenantId・userId が未セットの場合は購読しない
+    if (!tenantId || !userId) return;
+
+    // 購読するチャンネルパスを構築
+    const channel = `tickets/orders/${tenantId}/${userId}`;
+    switch (config.appEnv) {
       case "prd":
-        return subscribeChannel(addEvent, setError);
+        return subscribeChannel(channel, addEvent, setError);
       case "local":
+        console.log(
+          "[Subscription] ローカル環境のため WebSocket 接続をスキップ。イベント追加は postTicketOrder のモック実装が直接行う"
+        );
         return;
       default:
-        throw new Error(`Unknown VITE_APP_ENV: ${import.meta.env.VITE_APP_ENV}`);
+        throw new Error(`Unknown VITE_APP_ENV: ${config.appEnv}`);
     }
-  }, [addEvent]);
+  }, [addEvent, tenantId, userId]);
 
   return { error };
 }
@@ -54,39 +71,53 @@ export function useEventSubscription(): { error: string | null } {
 /**
  * AppSync Events チャンネルに接続してイベントを購読する
  *
+ * @param channel - 購読するチャンネルパス (例: "tickets/orders/{tenantId}/{userId}")
  * @param addEvent - 受信したイベントをストアに追加するコールバック
  * @param setError - エラーメッセージをセットするコールバック
  * @returns チャンネルをクローズするクリーンアップ関数
  */
 function subscribeChannel(
+  channel: string,
   addEvent: (item: EventItem) => void,
   setError: (msg: string) => void
 ): () => void {
-  console.log("[Subscription] 開始: tickets/orders");
-  let channel: EventsChannel | null = null;
+  console.log(`[Subscription] 開始: ${channel}`);
 
+  // 接続成功後にチャンネルをクローズするため、外部で変数を宣言しておく
+  let ch: EventsChannel | null = null;
+
+  // AppSync Events チャンネルに接続してイベントを購読
   events
-    .connect("tickets/orders")
-    .then((ch) => {
-      channel = ch;
-      ch.subscribe({
+    // 接続開始。接続成功後に then() で購読開始、失敗したら catch() でエラーハンドリングする
+    .connect(channel)
+
+    // 接続成功
+    .then((c) => {
+      ch = c;
+      // 購読開始。受信イベントは addEvent でストアに追加、エラーは setError でエラーメッセージをセットする
+      c.subscribe({
         next: (data: ReceivedEvent) => {
           console.log("[Subscription] next:", JSON.stringify(data));
           addEvent(buildEventItem(data.event.event_type, data.event.payload));
         },
+
+        // 購読エラーは接続エラーと同様に扱う
         error: (err: unknown) => {
           console.error("[Subscription] error:", err);
           setError(err instanceof Error ? err.message : "Subscription 接続に失敗しました");
         },
       });
     })
+
+    // 接続エラー
     .catch((err: unknown) => {
       console.error("[Subscription] connect error:", err);
       setError(err instanceof Error ? err.message : "WebSocket 接続に失敗しました");
     });
 
   return () => {
-    console.log("[Subscription] 終了");
-    channel?.close();
+    // クリーンアップ関数。チャンネルが存在すればクローズする
+    console.log(`[Subscription] 終了: ${channel}`);
+    ch?.close();
   };
 }

--- a/frontend/src/features/event-sender/api/index.ts
+++ b/frontend/src/features/event-sender/api/index.ts
@@ -1,3 +1,4 @@
+import { config } from "@app/config";
 import { post } from "@shared/api/http";
 import { useEventFeedStore } from "@features/event-feed/model/store";
 
@@ -25,7 +26,7 @@ interface PostTicketOrderRequest {
  * "prd" のときは API Lambda へ HTTP リクエストを送信する。
  */
 export async function postTicketOrder(req: PostTicketOrderRequest): Promise<void> {
-  if (import.meta.env.VITE_APP_ENV === "local") {
+  if (config.appEnv === "local") {
     await new Promise((resolve) => setTimeout(resolve, 3000));
     useEventFeedStore.getState().addEvent({
       event_id: crypto.randomUUID(),

--- a/frontend/src/shared/api/http.ts
+++ b/frontend/src/shared/api/http.ts
@@ -1,4 +1,6 @@
-const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+import { config } from "@app/config";
+
+const BASE_URL = config.apiBaseUrl;
 
 /**
  * GET リクエストを送信する


### PR DESCRIPTION
## 概要

v1 では全ユーザーが共通チャンネル `tickets/orders` を購読していた。
v2 では Zustand から取得した `tenantId` / `userId` を使い、`tickets/orders/{tenantId}/{userId}` へのテナント別購読に変更する。

## 変更内容

- `useEventSubscription.ts` の購読チャンネルを `tickets/orders/{tenantId}/{userId}` に変更
- `tenantId` / `userId` が null の場合は Subscribe しない制御を追加
- サインアウト時は `clearAuth()` で両値が null になり、`useEffect` クリーンアップで自動切断
- `import.meta.env` への直接アクセスを `src/app/config.ts` に集約し、各ファイルは `config.appEnv` / `config.apiBaseUrl` を参照するよう変更

## 関連 Issue / Discussion

- Closes #107

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] `npx tsc --noEmit` で型エラーがないことを確認

## レビュー観点

サインアウト時の unsubscribe は `App.tsx` を変更せず、`clearAuth()` → tenantId/userId が null → `useEffect` の依存値変化 → クリーンアップで `ch?.close()` という連鎖で実現している。
明示的な unsubscribe 呼び出しを追加していないため、意図通り動作するか確認してほしい。