### PR TITLE
[backend] [issue-108] [feat] API Lambda — JWT 検証・テナント情報伝播

### DIFF
--- a/.claude/rules/go/coding.md
+++ b/.claude/rules/go/coding.md
@@ -23,3 +23,77 @@ import (
     aws_eventbridge "github.com/aws/aws-sdk-go-v2/service/eventbridge"
 )
 ```
+
+## errcheck
+
+### レスポンスボディのクローズ
+
+`resp.Body.Close()` は戻り値を必ずチェックする。
+
+```go
+// NG
+defer resp.Body.Close()
+
+// OK
+defer func() {
+    if err := resp.Body.Close(); err != nil {
+        log.Println(err)
+    }
+}()
+```
+
+### 型アサーション
+
+`check-type-assertions: true` / `check-blank: true` が有効なため、型アサーションで ok を `_` で捨てない。if-ok パターンを使う。
+
+```go
+// NG
+tenantID, _ := claims["custom:tenantId"].(string)
+
+// OK
+var tenantID string
+if v, ok := claims["custom:tenantId"].(string); ok {
+    tenantID = v
+}
+```
+
+## govet
+
+### shadow — err の再宣言
+
+スコープ内で既に宣言済みの `err` を `:=` で再宣言しない。`=` を使って既存の変数に代入する。
+
+```go
+// NG: err が shadow される
+sig, err := decode(parts[2])
+if err := verify(sig); err != nil { ... }
+
+// OK
+sig, err := decode(parts[2])
+if err = verify(sig); err != nil { ... }
+```
+
+### fieldalignment — 構造体フィールドの順序
+
+GC スキャン範囲を最小化するため、ポインタを含むフィールドを先頭にまとめ、非ポインタフィールドを末尾に置く。
+
+| 型                                          | ポインタ含む |
+| ------------------------------------------- | ------------ |
+| `string`, `[]T`, `map`, `*T`, `interface{}` | 含む         |
+| `int`, `uint32`, `bool`, `sync.RWMutex` 等  | 含まない     |
+
+```go
+// NG
+type example struct {
+    name string       // pointer
+    mu   sync.Mutex   // 非ポインタ (間に挟まると GC スキャン範囲が広がる)
+    data map[string]any // pointer
+}
+
+// OK: ポインタ含むフィールドを先頭に集める
+type example struct {
+    name string
+    data map[string]any
+    mu   sync.Mutex
+}
+```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,11 @@
 APP_ENV=local
 APP_PORT=8080
 API_SERVICE_NAME=realtime-event-api
+SQS_QUEUE_URL=https://sqs.ap-northeast-1.amazonaws.com/local/realtime-event-queue
 EVENT_SERVICE_NAME=realtime-event-lambda
 DYNAMODB_TABLE_NAME=realtime-event-table
 APPSYNC_ENDPOINT=https://localhost/graphql
 APPSYNC_API_KEY=da2-local
+COGNITO_REGION=ap-northeast-1
+COGNITO_USER_POOL_ID=ap-northeast-1_xxxxxxxxx
+

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/tamaco489/realtime-event-platform/backend/internal/handler/api"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/auth"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/producer"
 )
@@ -23,8 +24,14 @@ func main() {
 		log.Fatal(err)
 	}
 
+	var v auth.Verifier
+	// ローカル環境では JWT 検証をスキップ
+	if !cfg.App.Env.IsLocal() {
+		v = auth.NewVerifier(cfg.Auth.Region, cfg.Auth.UserPoolID)
+	}
+
 	mux := http.NewServeMux()
-	mux.Handle("POST /v1/tickets/orders", api.NewHandler(p))
+	mux.Handle("POST /v1/tickets/orders", api.NewHandler(p, v, cfg.App.Env.IsLocal()))
 
 	log.Printf("service=%s started on :%s", cfg.App.ServiceName, cfg.App.Port)
 
@@ -37,7 +44,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -24,11 +24,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var v auth.Verifier
-	// ローカル環境では JWT 検証をスキップ
-	if !cfg.App.Env.IsLocal() {
-		v = auth.NewVerifier(cfg.Auth.Region, cfg.Auth.UserPoolID)
-	}
+	v := auth.NewVerifier(cfg.Auth.Region, cfg.Auth.UserPoolID)
 
 	mux := http.NewServeMux()
 	mux.Handle("POST /v1/tickets/orders", api.NewHandler(p, v, cfg.App.Env.IsLocal()))

--- a/backend/internal/handler/api/handler.go
+++ b/backend/internal/handler/api/handler.go
@@ -4,14 +4,20 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/auth"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/producer"
 )
 
-type Handler struct{ producer producer.Producer }
+type Handler struct {
+	producer producer.Producer
+	verifier auth.Verifier
+	isLocal  bool
+}
 
-func NewHandler(p producer.Producer) *Handler {
-	return &Handler{producer: p}
+func NewHandler(p producer.Producer, v auth.Verifier, isLocal bool) *Handler {
+	return &Handler{producer: p, verifier: v, isLocal: isLocal}
 }
 
 type postTicketOrderRequest struct {
@@ -25,6 +31,8 @@ type postTicketOrderRequest struct {
 type sqsMessage struct {
 	Payload   map[string]any `json:"payload"`
 	EventType string         `json:"event_type"`
+	TenantID  string         `json:"tenant_id"`
+	UserID    string         `json:"user_id"`
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -33,6 +41,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Println(err)
 		}
 	}()
+
+	claims, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
 
 	var req postTicketOrderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -52,6 +65,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	msg := sqsMessage{
 		EventType: "created",
+		TenantID:  claims.TenantID,
+		UserID:    claims.UserID,
 		Payload: map[string]any{
 			"event_id":   req.EventID,
 			"event_name": req.EventName,
@@ -73,6 +88,37 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// authenticate はローカル環境では固定クレームを返す。本番環境では JWT を検証する。
+func (h *Handler) authenticate(w http.ResponseWriter, r *http.Request) (*auth.Claims, bool) {
+	if h.isLocal {
+		return &auth.Claims{TenantID: "tenant-xxx01", UserID: "local-user-id"}, true
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		writeJSONError(w, "authorization header is required", http.StatusUnauthorized)
+		return nil, false
+	}
+	tokenString, ok := strings.CutPrefix(authHeader, "Bearer ")
+	if !ok || tokenString == "" {
+		writeJSONError(w, "authorization header must be Bearer token", http.StatusUnauthorized)
+		return nil, false
+	}
+
+	claims, err := h.verifier.Verify(r.Context(), tokenString)
+	if err != nil {
+		writeJSONError(w, "invalid or expired token", http.StatusUnauthorized)
+		return nil, false
+	}
+
+	if claims.TenantID == "" || claims.UserID == "" {
+		writeJSONError(w, "tenantId or userId missing in token", http.StatusForbidden)
+		return nil, false
+	}
+
+	return claims, true
 }
 
 func writeJSONError(w http.ResponseWriter, msg string, code int) {

--- a/backend/internal/handler/api/handler_test.go
+++ b/backend/internal/handler/api/handler_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/auth"
 )
 
 type mockProducer struct {
@@ -16,6 +18,93 @@ type mockProducer struct {
 
 func (m *mockProducer) Send(_ context.Context, _ string) error {
 	return m.err
+}
+
+// validClaims は正常系テストで使う固定クレーム
+var validClaims = &auth.Claims{TenantID: "tenant-xxx01", UserID: "user-001"}
+
+func TestHandler_ServeHTTP_Auth(t *testing.T) {
+	t.Parallel()
+
+	validBody := `{"event_id":"evt-001","event_name":"技術カンファレンス 2026","seat_type":"general","quantity":1,"amount":5000}`
+
+	tests := map[string]struct {
+		mockClaims  *auth.Claims
+		mockAuthErr error
+		authHeader  string
+		wantError   string
+		wantStatus  int
+	}{
+		"異常系_Authorization_ヘッダーなし": {
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "authorization header is required",
+		},
+		"異常系_Bearer_プレフィックスなし": {
+			authHeader: "invalid-token",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "authorization header must be Bearer token",
+		},
+		"異常系_Bearer_のみでトークンなし": {
+			authHeader: "Bearer ",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "authorization header must be Bearer token",
+		},
+		"異常系_JWT_検証エラー": {
+			authHeader:  "Bearer bad.token.here",
+			mockAuthErr: errors.New("invalid signature"),
+			wantStatus:  http.StatusUnauthorized,
+			wantError:   "invalid or expired token",
+		},
+		"異常系_tenantId_が空": {
+			authHeader: "Bearer valid.token.here",
+			mockClaims: &auth.Claims{TenantID: "", UserID: "user-001"},
+			wantStatus: http.StatusForbidden,
+			wantError:  "tenantId or userId missing in token",
+		},
+		"異常系_userId_が空": {
+			authHeader: "Bearer valid.token.here",
+			mockClaims: &auth.Claims{TenantID: "tenant-xxx01", UserID: ""},
+			wantStatus: http.StatusForbidden,
+			wantError:  "tenantId or userId missing in token",
+		},
+		"正常系_有効な_JWT": {
+			authHeader: "Bearer valid.token.here",
+			mockClaims: validClaims,
+			wantStatus: http.StatusAccepted,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := &auth.MockVerifier{Claims: tt.mockClaims, Err: tt.mockAuthErr}
+			h := NewHandler(&mockProducer{}, v, false)
+			req := httptest.NewRequest(http.MethodPost, "/v1/tickets/orders", strings.NewReader(validBody))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+
+			h.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if tt.wantError != "" {
+				var resp map[string]string
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response body: %v", err)
+				}
+				if resp["error"] != tt.wantError {
+					t.Errorf("error = %q, want %q", resp["error"], tt.wantError)
+				}
+			}
+		})
+	}
 }
 
 func TestHandler_ServeHTTP(t *testing.T) {
@@ -77,7 +166,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			h := NewHandler(&mockProducer{err: tt.producerErr})
+			// isLocal=true でリクエストボディのみをテストする
+			h := NewHandler(&mockProducer{err: tt.producerErr}, nil, true)
 			req := httptest.NewRequest(http.MethodPost, "/v1/tickets/orders", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()

--- a/backend/internal/library/auth/interface.go
+++ b/backend/internal/library/auth/interface.go
@@ -1,0 +1,14 @@
+package auth
+
+import "context"
+
+// Claims は JWT から抽出するテナント認証情報
+type Claims struct {
+	TenantID string
+	UserID   string
+}
+
+// Verifier は JWT を検証してクレームを返すインターフェース
+type Verifier interface {
+	Verify(ctx context.Context, token string) (*Claims, error)
+}

--- a/backend/internal/library/auth/jwks.go
+++ b/backend/internal/library/auth/jwks.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// jwk は JWKS エンドポイントから取得する JSON Web Key の単一エントリ
+type jwk struct {
+	Kid string `json:"kid"` // 鍵識別子。JWT ヘッダーの kid と照合して対応する公開鍵を特定する
+	Alg string `json:"alg"` // 署名アルゴリズム (例: "RS256")
+	N   string `json:"n"`   // RSA 公開鍵の modulus (Base64URL エンコード)
+	E   string `json:"e"`   // RSA 公開鍵の exponent (Base64URL エンコード)
+}
+
+// jwks は JWKS エンドポイントのレスポンス全体
+type jwks struct {
+	Keys []jwk `json:"keys"` // 公開鍵の一覧
+}
+
+// jwksVerifier は JWKS をキャッシュして JWT を検証する実装
+type jwksVerifier struct {
+	keySet  map[string]*rsa.PublicKey // kid をキーとする公開鍵キャッシュ
+	jwksURL string                    // JWKS 取得先 URL
+	mu      sync.RWMutex              // keySet への並行アクセスを保護する
+}
+
+// NewVerifier は JWKS エンドポイントを使って JWT を検証する Verifier を返す
+func NewVerifier(region, userPoolID string) Verifier {
+	return &jwksVerifier{
+		jwksURL: fmt.Sprintf("https://cognito-idp.%s.amazonaws.com/%s/.well-known/jwks.json", region, userPoolID),
+		keySet:  make(map[string]*rsa.PublicKey),
+	}
+}
+
+// fetchKeys は JWKS エンドポイントから公開鍵を取得してキャッシュに格納する
+func (v *jwksVerifier) fetchKeys(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURL, nil)
+	if err != nil {
+		return fmt.Errorf("create JWKS request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch JWKS: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	var set jwks
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		return fmt.Errorf("decode JWKS: %w", err)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	for _, k := range set.Keys {
+		pub, err := parseJWK(k)
+		if err != nil {
+			continue
+		}
+		v.keySet[k.Kid] = pub
+	}
+	return nil
+}
+
+// parseJWK は JWK の n・e フィールドから RSA 公開鍵を生成する
+func parseJWK(k jwk) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(new(big.Int).SetBytes(eBytes).Int64()),
+	}, nil
+}

--- a/backend/internal/library/auth/mock.go
+++ b/backend/internal/library/auth/mock.go
@@ -1,0 +1,14 @@
+package auth
+
+import "context"
+
+// MockVerifier はテスト・ローカル環境用のモック実装
+type MockVerifier struct {
+	Claims *Claims
+	Err    error
+}
+
+// Verify は設定済みの Claims と Err をそのまま返す
+func (m *MockVerifier) Verify(_ context.Context, _ string) (*Claims, error) {
+	return m.Claims, m.Err
+}

--- a/backend/internal/library/auth/verify.go
+++ b/backend/internal/library/auth/verify.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// getKey はキャッシュから公開鍵を取得する。未キャッシュの場合は fetchKeys で取得してから返す
+func (v *jwksVerifier) getKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	v.mu.RLock()
+	key, ok := v.keySet[kid]
+	v.mu.RUnlock()
+	if ok {
+		return key, nil
+	}
+
+	if err := v.fetchKeys(ctx); err != nil {
+		return nil, err
+	}
+
+	v.mu.RLock()
+	key, ok = v.keySet[kid]
+	v.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("key %s not found in JWKS", kid)
+	}
+	return key, nil
+}
+
+// Verify は JWT の署名・有効期限を検証し、tenantId・userId を抽出して返す
+func (v *jwksVerifier) Verify(ctx context.Context, token string) (*Claims, error) {
+	kid, err := extractKid(token)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := v.getKey(ctx, kid)
+	if err != nil {
+		return nil, err
+	}
+
+	rawClaims, err := verifyRS256(token, key)
+	if err != nil {
+		return nil, err
+	}
+
+	var tenantID, userID string
+	if v, ok := rawClaims["custom:tenantId"].(string); ok {
+		tenantID = v
+	}
+	if v, ok := rawClaims["sub"].(string); ok {
+		userID = v
+	}
+
+	return &Claims{TenantID: tenantID, UserID: userID}, nil
+}
+
+// extractKid は JWT ヘッダーから kid と alg を検証して kid を返す
+func extractKid(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", errors.New("malformed token")
+	}
+
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("decode header: %w", err)
+	}
+
+	var header struct {
+		Kid string `json:"kid"`
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return "", fmt.Errorf("parse header: %w", err)
+	}
+	if header.Alg != "RS256" {
+		return "", fmt.Errorf("unexpected alg: %s", header.Alg)
+	}
+	if header.Kid == "" {
+		return "", errors.New("kid missing in token header")
+	}
+	return header.Kid, nil
+}
+
+// verifyRS256 は RS256 署名を検証し、有効期限チェック後にクレームを返す
+func verifyRS256(token string, key *rsa.PublicKey) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("malformed token")
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+
+	h := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err = rsa.VerifyPKCS1v15(key, crypto.SHA256, h[:], sig); err != nil {
+		return nil, fmt.Errorf("invalid signature: %w", err)
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("parse claims: %w", err)
+	}
+
+	if exp, ok := claims["exp"].(float64); ok && time.Now().Unix() > int64(exp) {
+		return nil, errors.New("token expired")
+	}
+
+	return claims, nil
+}

--- a/backend/internal/library/config/api_config.go
+++ b/backend/internal/library/config/api_config.go
@@ -9,6 +9,7 @@ import (
 type APIConfig struct {
 	App      APIAppConfig
 	Producer ProducerConfig
+	Auth     AuthConfig
 }
 
 type APIAppConfig struct {
@@ -18,7 +19,12 @@ type APIAppConfig struct {
 }
 
 type ProducerConfig struct {
-	QueueURL string `env:"SQS_QUEUE_URL"`
+	QueueURL string `env:"SQS_QUEUE_URL,required,notEmpty"`
+}
+
+type AuthConfig struct {
+	Region     string `env:"COGNITO_REGION,required,notEmpty"`
+	UserPoolID string `env:"COGNITO_USER_POOL_ID,required,notEmpty"`
 }
 
 func APILoad() (*APIConfig, error) {

--- a/backend/tools/httprequest/dev/post_events.http
+++ b/backend/tools/httprequest/dev/post_events.http
@@ -1,52 +1,60 @@
 @baseUrl = http://localhost:18080
 
 ###
-# POST /events — 正常系: 標準的なイベント送信
-POST {{baseUrl}}/events
+# POST /v1/tickets/orders — 正常系: general 席
+POST {{baseUrl}}/v1/tickets/orders
 Content-Type: application/json
 
 {
-  "event_type": "test",
-  "payload": {
-    "message": "test"
-  }
+  "event_id": "evt-001",
+  "event_name": "技術カンファレンス 2026",
+  "seat_type": "general",
+  "quantity": 2,
+  "amount": 10000
 }
 
 ###
-# POST /events — 正常系: payload にデータを含む
-POST {{baseUrl}}/events
+# POST /v1/tickets/orders — 正常系: vip 席
+POST {{baseUrl}}/v1/tickets/orders
 Content-Type: application/json
 
 {
-  "event_type": "user.created",
-  "payload": {
-    "user_id": "u-001",
-    "name": "tamaco"
-  }
+  "event_id": "evt-002",
+  "event_name": "音楽フェス 2026",
+  "seat_type": "vip",
+  "quantity": 1,
+  "amount": 30000
 }
 
 ###
-# POST /events — 異常系: event_type が空
-POST {{baseUrl}}/events
+# POST /v1/tickets/orders — 異常系: event_id が空
+POST {{baseUrl}}/v1/tickets/orders
 Content-Type: application/json
 
 {
-  "event_type": "",
-  "payload": {}
+  "event_id": "",
+  "event_name": "技術カンファレンス 2026",
+  "seat_type": "general",
+  "quantity": 1,
+  "amount": 5000
 }
 
 ###
-# POST /events — 異常系: event_type が欠落
-POST {{baseUrl}}/events
+# POST /v1/tickets/orders — 異常系: quantity が 0
+POST {{baseUrl}}/v1/tickets/orders
 Content-Type: application/json
 
 {
-  "payload": {}
+  "event_id": "evt-001",
+  "event_name": "技術カンファレンス 2026",
+  "seat_type": "general",
+  "quantity": 0,
+  "amount": 5000
 }
 
 ###
-# POST /events — 異常系: 不正な JSON ボディ
-POST {{baseUrl}}/events
+# POST /v1/tickets/orders — 異常系: 不正な JSON ボディ
+POST {{baseUrl}}/v1/tickets/orders
 Content-Type: application/json
 
 { invalid json }


### PR DESCRIPTION
## 概要

v1 では API Lambda が認証なしでリクエストを受け付けていた。
v2 では Authorization ヘッダーから JWT を取得し、Cognito JWKS で署名を検証して tenantId・userId を抽出する。
抽出した情報を SQS メッセージに埋め込み、Event Lambda へ伝播させる。

## 変更内容

- `internal/library/auth/` パッケージを新設し、JWKS 取得・RS256 署名検証・クレーム抽出を実装
- `handler.go` に JWT 取得・検証・クレーム抽出を追加 (401 / 403 ハンドリング含む)
- `sqsMessage` に `tenant_id` / `user_id` フィールドを追加
- ローカル環境 (`APP_ENV=local`) では JWT 検証をスキップし、固定クレームを使用
- CORS ミドルウェアの許可ヘッダーに `Authorization` を追加
- `AuthConfig` (`COGNITO_REGION`, `COGNITO_USER_POOL_ID`) を `api_config.go` に追加
- dev 向け HTTP リクエストファイルのエンドポイントを `/v1/tickets/orders` に修正
- Go コーディングルールに lint 対応ルール (errcheck / govet) を追記

## 関連 Issue / Discussion

- Closes #108

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] 関連するテストが通ることを確認 (`make verify`)
- [x] ローカル環境でリクエストを投げて `202 Accepted` を確認

## レビュー観点

> [!NOTE]
> `auth/` パッケージは外部ライブラリを追加せず、標準ライブラリのみで RS256 検証を実装している。
> JWKS 公開鍵はインメモリキャッシュ (`sync.RWMutex` + `map`) で保持し、kid ミス時のみ再フェッチする。

> [!IMPORTANT]
> ローカル環境では `isLocal=true` により JWT 検証ブロックを丸ごとスキップし、固定クレームを返す。
> 本番環境では `COGNITO_REGION` / `COGNITO_USER_POOL_ID` が必須 (`required,notEmpty`)。