### PR TITLE
[backend] [issue-109] [feat] Event Lambda — テナント分離・IAM 認証

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,11 +1,9 @@
 APP_ENV=local
 APP_PORT=8080
 API_SERVICE_NAME=realtime-event-api
+AWS_REGION=ap-northeast-1
 SQS_QUEUE_URL=https://sqs.ap-northeast-1.amazonaws.com/local/realtime-event-queue
 EVENT_SERVICE_NAME=realtime-event-lambda
 DYNAMODB_TABLE_NAME=realtime-event-table
 APPSYNC_ENDPOINT=https://localhost/graphql
-APPSYNC_API_KEY=da2-local
-COGNITO_REGION=ap-northeast-1
 COGNITO_USER_POOL_ID=ap-northeast-1_xxxxxxxxx
-

--- a/backend/cmd/event/main.go
+++ b/backend/cmd/event/main.go
@@ -30,12 +30,13 @@ func main() {
 		cfg.App.Env,
 		cfg.Notifier.Endpoint,
 		cfg.Notifier.Channel,
-		cfg.Notifier.APIKey,
+		cfg.Notifier.Region,
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	h := event.NewHandler(s, n)
+
 	lambda.Start(h.Handle)
 }

--- a/backend/internal/handler/event/handler.go
+++ b/backend/internal/handler/event/handler.go
@@ -22,16 +22,21 @@ func NewHandler(s store.EventWriter, n notifier.EventPublisher) *Handler {
 	return &Handler{store: s, notifier: n}
 }
 
+// eventMessage は SQS から受け取るメッセージ構造
 type eventMessage struct {
 	Payload   map[string]any `json:"payload"`
 	EventType string         `json:"event_type"`
+	TenantID  string         `json:"tenant_id"`
+	UserID    string         `json:"user_id"`
 }
 
+// Handle は SQS イベントを受け取り、各レコードを処理する
+//
+// 失敗したレコードはパーシャルバッチ失敗として BatchItemFailures に積み、DLQ へ転送する
 func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) (events.SQSEventResponse, error) {
 	log.Printf("event handler invoked: records=%d", len(sqsEvent.Records))
 
 	var resp events.SQSEventResponse
-
 	for _, record := range sqsEvent.Records {
 		if err := h.processRecord(ctx, record); err != nil {
 			log.Printf("failure: message_id=%s err=%v", record.MessageId, err)
@@ -47,31 +52,49 @@ func (h *Handler) Handle(ctx context.Context, sqsEvent events.SQSEvent) (events.
 	return resp, nil
 }
 
+// processRecord は SQS の単一レコードを処理する
 func (h *Handler) processRecord(ctx context.Context, record events.SQSMessage) error {
 	var msg eventMessage
 	if err := json.Unmarshal([]byte(record.Body), &msg); err != nil {
 		return err
 	}
 
-	// NOTE: イベントの処理に時間がかかるケースを想定して、敢えて Sleep で遅延させている
-	time.Sleep(3 * time.Second)
-
-	if err := h.store.PutEvent(ctx, msg.EventType, msg.Payload); err != nil {
+	// tenant_id または user_id が欠如している場合はエラーを返す
+	if err := msg.validate(record.MessageId); err != nil {
 		return err
 	}
 
+	// NOTE: イベントの処理に時間がかかるケースを想定して、敢えて Sleep で遅延させている
+	time.Sleep(3 * time.Second)
+
+	// UUID v7 を order_id として生成
 	orderID, err := uuid.NewV7()
 	if err != nil {
 		return fmt.Errorf("failed to generate order_id: %w", err)
 	}
+
+	// DynamoDB に状態を保存
+	if err = h.store.PutEvent(ctx, msg.TenantID, msg.UserID, orderID.String(), msg.EventType, msg.Payload); err != nil {
+		return err
+	}
+
+	// AppSync にイベントを Publish
 	publishPayload := map[string]any{
 		"order_id": "ord-" + orderID.String(),
 		"status":   "confirmed",
 	}
-	if err := h.notifier.PublishEvent(ctx, msg.EventType, publishPayload); err != nil {
+	if err = h.notifier.PublishEvent(ctx, msg.EventType, publishPayload, msg.TenantID, msg.UserID); err != nil {
 		return err
 	}
 
-	log.Printf("processed: message_id=%s event_type=%s", record.MessageId, msg.EventType)
+	log.Printf("processed: message_id=%s event_type=%s tenant_id=%s user_id=%s", record.MessageId, msg.EventType, msg.TenantID, msg.UserID)
+	return nil
+}
+
+// validate は tenant_id または user_id が欠如している場合にエラーを返す
+func (m *eventMessage) validate(messageID string) error {
+	if m.TenantID == "" || m.UserID == "" {
+		return fmt.Errorf("tenant_id or user_id is missing: message_id=%s", messageID)
+	}
 	return nil
 }

--- a/backend/internal/handler/event/handler_test.go
+++ b/backend/internal/handler/event/handler_test.go
@@ -12,7 +12,7 @@ type mockStore struct {
 	err error
 }
 
-func (m *mockStore) PutEvent(_ context.Context, _ string, _ map[string]any) error {
+func (m *mockStore) PutEvent(_ context.Context, _, _, _, _ string, _ map[string]any) error {
 	return m.err
 }
 
@@ -20,7 +20,7 @@ type mockNotifier struct {
 	err error
 }
 
-func (m *mockNotifier) PublishEvent(_ context.Context, _ string, _ map[string]any) error {
+func (m *mockNotifier) PublishEvent(_ context.Context, _ string, _ map[string]any, _, _ string) error {
 	return m.err
 }
 
@@ -34,19 +34,27 @@ func TestHandler_Handle(t *testing.T) {
 		wantFailureIDs []string
 	}{
 		"正常系_有効なレコードを処理できる": {
-			body: `{"event_type":"user.created","payload":{"user_id":"u-001"}}`,
+			body: `{"event_type":"tickets.ordered","tenant_id":"tenant-xxx01","user_id":"user-001","payload":{"event_id":"evt-001"}}`,
 		},
 		"異常系_不正な_JSON_は_BatchItemFailures_に積まれる": {
 			body:           `{ invalid }`,
 			wantFailureIDs: []string{"test-id"},
 		},
+		"異常系_tenant_id_が空は_BatchItemFailures_に積まれる": {
+			body:           `{"event_type":"tickets.ordered","tenant_id":"","user_id":"user-001","payload":{}}`,
+			wantFailureIDs: []string{"test-id"},
+		},
+		"異常系_user_id_が空は_BatchItemFailures_に積まれる": {
+			body:           `{"event_type":"tickets.ordered","tenant_id":"tenant-xxx01","user_id":"","payload":{}}`,
+			wantFailureIDs: []string{"test-id"},
+		},
 		"異常系_store_エラーは_BatchItemFailures_に積まれる": {
-			body:           `{"event_type":"user.created","payload":{}}`,
+			body:           `{"event_type":"tickets.ordered","tenant_id":"tenant-xxx01","user_id":"user-001","payload":{}}`,
 			storeErr:       errors.New("dynamodb error"),
 			wantFailureIDs: []string{"test-id"},
 		},
 		"異常系_notifier_エラーは_BatchItemFailures_に積まれる": {
-			body:           `{"event_type":"user.created","payload":{}}`,
+			body:           `{"event_type":"tickets.ordered","tenant_id":"tenant-xxx01","user_id":"user-001","payload":{}}`,
 			notifierErr:    errors.New("appsync error"),
 			wantFailureIDs: []string{"test-id"},
 		},

--- a/backend/internal/library/config/api_config.go
+++ b/backend/internal/library/config/api_config.go
@@ -23,7 +23,7 @@ type ProducerConfig struct {
 }
 
 type AuthConfig struct {
-	Region     string `env:"COGNITO_REGION,required,notEmpty"`
+	Region     string `env:"AWS_REGION,required,notEmpty"`
 	UserPoolID string `env:"COGNITO_USER_POOL_ID,required,notEmpty"`
 }
 

--- a/backend/internal/library/config/event_config.go
+++ b/backend/internal/library/config/event_config.go
@@ -23,8 +23,8 @@ type StoreConfig struct {
 
 type NotifierConfig struct {
 	Endpoint string `env:"APPSYNC_ENDPOINT"`
-	APIKey   string `env:"APPSYNC_API_KEY"`
 	Channel  string `env:"APPSYNC_CHANNEL"`
+	Region   string `env:"AWS_REGION"`
 }
 
 func EventLoad() (*EventConfig, error) {

--- a/backend/internal/library/notifier/client.go
+++ b/backend/internal/library/notifier/client.go
@@ -5,30 +5,47 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 )
 
+// notifier は AppSync Events HTTP Publish API クライアント
 type notifier struct {
+	creds    aws.CredentialsProvider
+	signer   *v4.Signer
 	client   *http.Client
 	endpoint string
 	channel  string
-	apiKey   string
+	region   string
 }
 
+// NewNotifier は AppSync Events Publish クライアントを生成する
+//
+// ローカル環境ではモック実装を返す
 func NewNotifier(
-	_ context.Context,
+	ctx context.Context,
 	env config.Environment,
-	endpoint, channel, apiKey string,
+	endpoint, channel, region string,
 ) (EventPublisher, error) {
 	if env.IsLocal() {
 		log.Println("notifier: running in mock mode")
 		return &mockPublisher{}, nil
 	}
 
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &notifier{
+		creds:    cfg.Credentials,
+		signer:   v4.NewSigner(),
 		client:   &http.Client{},
 		endpoint: endpoint,
 		channel:  channel,
-		apiKey:   apiKey,
+		region:   region,
 	}, nil
 }

--- a/backend/internal/library/notifier/client.go
+++ b/backend/internal/library/notifier/client.go
@@ -6,25 +6,22 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	lib_config "github.com/aws/aws-sdk-go-v2/config"
+
+	signer "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/library/config"
 )
 
-// notifier は AppSync Events HTTP Publish API クライアント
 type notifier struct {
 	creds    aws.CredentialsProvider
-	signer   *v4.Signer
+	signer   *signer.Signer
 	client   *http.Client
 	endpoint string
 	channel  string
 	region   string
 }
 
-// NewNotifier は AppSync Events Publish クライアントを生成する
-//
-// ローカル環境ではモック実装を返す
 func NewNotifier(
 	ctx context.Context,
 	env config.Environment,
@@ -35,14 +32,14 @@ func NewNotifier(
 		return &mockPublisher{}, nil
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	cfg, err := lib_config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &notifier{
 		creds:    cfg.Credentials,
-		signer:   v4.NewSigner(),
+		signer:   signer.NewSigner(),
 		client:   &http.Client{},
 		endpoint: endpoint,
 		channel:  channel,

--- a/backend/internal/library/notifier/interface.go
+++ b/backend/internal/library/notifier/interface.go
@@ -3,5 +3,5 @@ package notifier
 import "context"
 
 type EventPublisher interface {
-	PublishEvent(ctx context.Context, eventType string, payload map[string]any) error
+	PublishEvent(ctx context.Context, eventType string, payload map[string]any, tenantID, userID string) error
 }

--- a/backend/internal/library/notifier/mock.go
+++ b/backend/internal/library/notifier/mock.go
@@ -7,7 +7,8 @@ import (
 
 type mockPublisher struct{}
 
-func (m *mockPublisher) PublishEvent(_ context.Context, eventType string, payload map[string]any) error {
-	log.Printf("[MOCK] AppSync PublishEvent: event_type=%s payload=%v\n", eventType, payload)
+// PublishEvent はローカル環境用モック実装
+func (m *mockPublisher) PublishEvent(_ context.Context, eventType string, payload map[string]any, tenantID, userID string) error {
+	log.Printf("[MOCK] AppSync PublishEvent: tenant_id=%s user_id=%s event_type=%s payload=%v\n", tenantID, userID, eventType, payload)
 	return nil
 }

--- a/backend/internal/library/notifier/mock.go
+++ b/backend/internal/library/notifier/mock.go
@@ -7,7 +7,6 @@ import (
 
 type mockPublisher struct{}
 
-// PublishEvent はローカル環境用モック実装
 func (m *mockPublisher) PublishEvent(_ context.Context, eventType string, payload map[string]any, tenantID, userID string) error {
 	log.Printf("[MOCK] AppSync PublishEvent: tenant_id=%s user_id=%s event_type=%s payload=%v\n", tenantID, userID, eventType, payload)
 	return nil

--- a/backend/internal/library/notifier/publish.go
+++ b/backend/internal/library/notifier/publish.go
@@ -13,23 +13,16 @@ import (
 	"time"
 )
 
-// eventsRequest は AppSync Events HTTP Publish API のリクエストボディ
 type eventsRequest struct {
-	// Channel は Publish 先のチャンネルパス
-	Channel string `json:"channel"`
-	// Events は Publish するイベントの JSON 文字列リスト
-	Events []string `json:"events"`
+	Channel string   `json:"channel"`
+	Events  []string `json:"events"`
 }
 
-// eventData は AppSync に Publish するイベントの本体
 type eventData struct {
-	// Payload はイベント固有のデータ
-	Payload map[string]any `json:"payload"`
-	// EventType はイベントの種別名
-	EventType string `json:"event_type"`
+	Payload   map[string]any `json:"payload"`
+	EventType string         `json:"event_type"`
 }
 
-// PublishEvent は指定テナント・ユーザーのチャンネルにイベントを Publish する
 func (n *notifier) PublishEvent(ctx context.Context, eventType string, payload map[string]any, tenantID, userID string) error {
 	edJSON, err := json.Marshal(eventData{EventType: eventType, Payload: payload})
 	if err != nil {

--- a/backend/internal/library/notifier/publish.go
+++ b/backend/internal/library/notifier/publish.go
@@ -3,31 +3,42 @@ package notifier
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"time"
 )
 
+// eventsRequest は AppSync Events HTTP Publish API のリクエストボディ
 type eventsRequest struct {
-	Channel string   `json:"channel"`
-	Events  []string `json:"events"`
+	// Channel は Publish 先のチャンネルパス
+	Channel string `json:"channel"`
+	// Events は Publish するイベントの JSON 文字列リスト
+	Events []string `json:"events"`
 }
 
+// eventData は AppSync に Publish するイベントの本体
 type eventData struct {
-	Payload   map[string]any `json:"payload"`
-	EventType string         `json:"event_type"`
+	// Payload はイベント固有のデータ
+	Payload map[string]any `json:"payload"`
+	// EventType はイベントの種別名
+	EventType string `json:"event_type"`
 }
 
-func (n *notifier) PublishEvent(ctx context.Context, eventType string, payload map[string]any) error {
+// PublishEvent は指定テナント・ユーザーのチャンネルにイベントを Publish する
+func (n *notifier) PublishEvent(ctx context.Context, eventType string, payload map[string]any, tenantID, userID string) error {
 	edJSON, err := json.Marshal(eventData{EventType: eventType, Payload: payload})
 	if err != nil {
 		return fmt.Errorf("appsync: failed to marshal event: %w", err)
 	}
 
+	channel := n.channel + "/" + tenantID + "/" + userID
 	body, err := json.Marshal(eventsRequest{
-		Channel: n.channel,
+		Channel: channel,
 		Events:  []string{string(edJSON)},
 	})
 	if err != nil {
@@ -40,7 +51,15 @@ func (n *notifier) PublishEvent(ctx context.Context, eventType string, payload m
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", n.apiKey)
+
+	creds, err := n.creds.Retrieve(ctx)
+	if err != nil {
+		return fmt.Errorf("appsync: failed to retrieve credentials: %w", err)
+	}
+	hash := sha256.Sum256(body)
+	if err = n.signer.SignHTTP(ctx, creds, req, hex.EncodeToString(hash[:]), "appsync", n.region, time.Now()); err != nil {
+		return fmt.Errorf("appsync: failed to sign request: %w", err)
+	}
 
 	resp, err := n.client.Do(req)
 	if err != nil {

--- a/backend/internal/library/store/interface.go
+++ b/backend/internal/library/store/interface.go
@@ -3,5 +3,5 @@ package store
 import "context"
 
 type EventWriter interface {
-	PutEvent(ctx context.Context, eventType string, payload map[string]any) error
+	PutEvent(ctx context.Context, tenantID, userID, orderID, eventType string, payload map[string]any) error
 }

--- a/backend/internal/library/store/mock.go
+++ b/backend/internal/library/store/mock.go
@@ -7,7 +7,6 @@ import (
 
 type mockWriter struct{}
 
-// PutEvent はローカル環境用モック実装
 func (m *mockWriter) PutEvent(_ context.Context, tenantID, userID, orderID, eventType string, payload map[string]any) error {
 	log.Printf("[MOCK] DynamoDB PutItem: tenant_id=%s user_id=%s order_id=%s event_type=%s payload=%v\n", tenantID, userID, orderID, eventType, payload)
 	return nil

--- a/backend/internal/library/store/mock.go
+++ b/backend/internal/library/store/mock.go
@@ -7,7 +7,8 @@ import (
 
 type mockWriter struct{}
 
-func (m *mockWriter) PutEvent(_ context.Context, eventType string, payload map[string]any) error {
-	log.Printf("[MOCK] DynamoDB PutItem: event_type=%s payload=%v\n", eventType, payload)
+// PutEvent はローカル環境用モック実装
+func (m *mockWriter) PutEvent(_ context.Context, tenantID, userID, orderID, eventType string, payload map[string]any) error {
+	log.Printf("[MOCK] DynamoDB PutItem: tenant_id=%s user_id=%s order_id=%s event_type=%s payload=%v\n", tenantID, userID, orderID, eventType, payload)
 	return nil
 }

--- a/backend/internal/library/store/put.go
+++ b/backend/internal/library/store/put.go
@@ -9,15 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/google/uuid"
 )
 
-func (s *store) PutEvent(ctx context.Context, eventType string, payload map[string]any) error {
-	eventID, err := uuid.NewV7()
-	if err != nil {
-		return err
-	}
-
+// PutEvent はテナント・ユーザー・オーダー情報を PK/SK として DynamoDB に保存する
+//
+// PK = tenantID#userID, SK = orderID (UUID v7)
+func (s *store) PutEvent(ctx context.Context, tenantID, userID, orderID, eventType string, payload map[string]any) error {
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -26,7 +23,8 @@ func (s *store) PutEvent(ctx context.Context, eventType string, payload map[stri
 	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(s.tableName),
 		Item: map[string]types.AttributeValue{
-			"event_id":   &types.AttributeValueMemberS{Value: eventID.String()},
+			"pk":         &types.AttributeValueMemberS{Value: tenantID + "#" + userID},
+			"sk":         &types.AttributeValueMemberS{Value: orderID},
 			"event_type": &types.AttributeValueMemberS{Value: eventType},
 			"payload":    &types.AttributeValueMemberS{Value: string(payloadJSON)},
 			"created_at": &types.AttributeValueMemberN{Value: strconv.FormatInt(time.Now().UTC().Unix(), 10)},

--- a/backend/internal/library/store/put.go
+++ b/backend/internal/library/store/put.go
@@ -11,9 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// PutEvent はテナント・ユーザー・オーダー情報を PK/SK として DynamoDB に保存する
-//
-// PK = tenantID#userID, SK = orderID (UUID v7)
 func (s *store) PutEvent(ctx context.Context, tenantID, userID, orderID, eventType string, payload map[string]any) error {
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -23,8 +20,8 @@ func (s *store) PutEvent(ctx context.Context, tenantID, userID, orderID, eventTy
 	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(s.tableName),
 		Item: map[string]types.AttributeValue{
-			"pk":         &types.AttributeValueMemberS{Value: tenantID + "#" + userID},
-			"sk":         &types.AttributeValueMemberS{Value: orderID},
+			"pk":         &types.AttributeValueMemberS{Value: tenantID + "#" + userID}, // tenantID#userID
+			"sk":         &types.AttributeValueMemberS{Value: orderID},                 // orderID (UUID v7)
 			"event_type": &types.AttributeValueMemberS{Value: eventType},
 			"payload":    &types.AttributeValueMemberS{Value: string(payloadJSON)},
 			"created_at": &types.AttributeValueMemberN{Value: strconv.FormatInt(time.Now().UTC().Unix(), 10)},

--- a/backend/tools/events/sqs_event.json
+++ b/backend/tools/events/sqs_event.json
@@ -3,7 +3,7 @@
     {
       "messageId": "test-message-id-1",
       "receiptHandle": "test-receipt-handle",
-      "body": "{\"event_type\":\"user.created\",\"payload\":{\"user_id\":\"u-001\",\"name\":\"tamaco\"}}",
+      "body": "{\"event_type\":\"tickets.ordered\",\"tenant_id\":\"tenant-xxx01\",\"user_id\":\"user-001\",\"payload\":{\"event_id\":\"evt-001\",\"event_name\":\"技術カンファレンス 2026\",\"seat_type\":\"general\",\"quantity\":2,\"amount\":10000}}",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1745982649183"


### PR DESCRIPTION
## 概要

v1 では Event Lambda がテナント情報を持たず共通チャンネルに Publish していた。
v2 では SQS メッセージに `tenant_id` / `user_id` を含め、DynamoDB のスキーマをテナント分離構造に変更し、AppSync への Publish 認証を API Key から IAM (SigV4) に切り替える。

## 変更内容

- SQS メッセージから `tenant_id` / `user_id` を抽出し、欠如時は BatchItemFailure に積んで DLQ へ転送する
- DynamoDB の PK を `tenantID#userID`、SK を `orderID` (UUID v7) に変更する
- AppSync の Publish チャンネルを `tickets/orders/{tenantID}/{userID}` に変更する
- `x-api-key` ヘッダーを廃止し、`aws/signer/v4` による SigV4 署名に切り替える
- `APPSYNC_API_KEY` / `COGNITO_REGION` / `APPSYNC_REGION` を廃止し `AWS_REGION` に統一する

## 関連 Issue / Discussion

- Closes #109
- Ref #111

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] 関連するテストが通ることを確認 (`make test`)

## レビュー観点

> [!IMPORTANT]
> `notifier/publish.go` の SigV4 署名実装は本番環境でのみ動作する (ローカルはモック)。
> IAM ロールへの `appsync:EventPublish` 権限付与は INFRA-012 (#111) で対応する。