### PR TITLE
[infra] [issue-112] [feat] DynamoDB スキーマ変更 + テスト + e2e 疎通確認

### DIFF
--- a/.github/workflows/ci-api.yaml
+++ b/.github/workflows/ci-api.yaml
@@ -1,0 +1,96 @@
+name: CI - API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/cmd/api/**"
+      - "backend/internal/handler/api/**"
+      - ".github/workflows/ci-api.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/cmd/api/**"
+      - "backend/internal/handler/api/**"
+      - ".github/workflows/ci-api.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Node.js 24 がデフォルト化される 2026-06-02 以降は削除可
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        id: cache-golangci-lint
+        with:
+          path: ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-v2.12.2
+
+      - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('backend/.golangci.yml', 'backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Build
+        run: make build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Test
+        run: make test

--- a/.github/workflows/ci-authorizer.yaml
+++ b/.github/workflows/ci-authorizer.yaml
@@ -1,28 +1,18 @@
-name: CI - Event
+name: CI - Authorizer
 
 on:
   push:
     branches: [main]
     paths:
-      - "backend/cmd/event/**"
-      - "backend/internal/handler/event/**"
-      - "backend/internal/library/**"
-      - "backend/go.mod"
-      - "backend/go.sum"
-      - "backend/Makefile"
-      - "backend/.golangci.yml"
-      - ".github/workflows/ci-event.yml"
+      - "backend/cmd/authorizer/**"
+      - "backend/internal/handler/authorizer/**"
+      - ".github/workflows/ci-authorizer.yaml"
   pull_request:
     branches: [main]
     paths:
-      - "backend/cmd/event/**"
-      - "backend/internal/handler/event/**"
-      - "backend/internal/library/**"
-      - "backend/go.mod"
-      - "backend/go.sum"
-      - "backend/Makefile"
-      - "backend/.golangci.yml"
-      - ".github/workflows/ci-event.yml"
+      - "backend/cmd/authorizer/**"
+      - "backend/internal/handler/authorizer/**"
+      - ".github/workflows/ci-authorizer.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-common.yaml
+++ b/.github/workflows/ci-common.yaml
@@ -1,0 +1,100 @@
+name: CI - Common (Backend Shared)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/.golangci.yml"
+      - ".github/workflows/ci-common.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/internal/library/**"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "backend/.golangci.yml"
+      - ".github/workflows/ci-common.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Node.js 24 がデフォルト化される 2026-06-02 以降は削除可
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        id: cache-golangci-lint
+        with:
+          path: ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-v2.12.2
+
+      - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('backend/.golangci.yml', 'backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Build
+        run: make build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Test
+        run: make test

--- a/.github/workflows/ci-event.yaml
+++ b/.github/workflows/ci-event.yaml
@@ -1,28 +1,18 @@
-name: CI - API
+name: CI - Event
 
 on:
   push:
     branches: [main]
     paths:
-      - "backend/cmd/api/**"
-      - "backend/internal/handler/api/**"
-      - "backend/internal/library/**"
-      - "backend/go.mod"
-      - "backend/go.sum"
-      - "backend/Makefile"
-      - "backend/.golangci.yml"
-      - ".github/workflows/ci-api.yml"
+      - "backend/cmd/event/**"
+      - "backend/internal/handler/event/**"
+      - ".github/workflows/ci-event.yaml"
   pull_request:
     branches: [main]
     paths:
-      - "backend/cmd/api/**"
-      - "backend/internal/handler/api/**"
-      - "backend/internal/library/**"
-      - "backend/go.mod"
-      - "backend/go.sum"
-      - "backend/Makefile"
-      - "backend/.golangci.yml"
-      - ".github/workflows/ci-api.yml"
+      - "backend/cmd/event/**"
+      - "backend/internal/handler/event/**"
+      - ".github/workflows/ci-event.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -5,12 +5,12 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
-      - ".github/workflows/ci-frontend.yml"
+      - ".github/workflows/ci-frontend.yaml"
   pull_request:
     branches: [main]
     paths:
       - "frontend/**"
-      - ".github/workflows/ci-frontend.yml"
+      - ".github/workflows/ci-frontend.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-infra.yaml
+++ b/.github/workflows/ci-infra.yaml
@@ -5,12 +5,12 @@ on:
     branches: [main]
     paths:
       - "infra/**"
-      - ".github/workflows/ci-infra.yml"
+      - ".github/workflows/ci-infra.yaml"
   pull_request:
     branches: [main]
     paths:
       - "infra/**"
-      - ".github/workflows/ci-infra.yml"
+      - ".github/workflows/ci-infra.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/backend/internal/handler/authorizer/handler_test.go
+++ b/backend/internal/handler/authorizer/handler_test.go
@@ -11,7 +11,10 @@ import (
 func TestHandler_Handle(t *testing.T) {
 	t.Parallel()
 
-	validClaims := &auth.Claims{TenantID: "tenant-abc", UserID: "user-123"}
+	validClaims := &auth.Claims{
+		TenantID: "tenant-abc",
+		UserID:   "user-123",
+	}
 
 	tests := map[string]struct {
 		mockClaims  *auth.Claims
@@ -53,6 +56,20 @@ func TestHandler_Handle(t *testing.T) {
 			token:      "Bearer valid.token.here",
 			channel:    "/tickets/orders/tenant-abc/other-user",
 			mockClaims: validClaims,
+			wantAuth:   false,
+			wantTTL:    0,
+		},
+		"異常系_claims_の_tenantId_が空の場合は_isAuthorized_false_を返す": {
+			token:      "Bearer valid.token.here",
+			channel:    "/tickets/orders/tenant-abc/user-123",
+			mockClaims: &auth.Claims{TenantID: "", UserID: "user-123"},
+			wantAuth:   false,
+			wantTTL:    0,
+		},
+		"異常系_claims_の_userId_が空の場合は_isAuthorized_false_を返す": {
+			token:      "Bearer valid.token.here",
+			channel:    "/tickets/orders/tenant-abc/user-123",
+			mockClaims: &auth.Claims{TenantID: "tenant-abc", UserID: ""},
 			wantAuth:   false,
 			wantTTL:    0,
 		},

--- a/backend/internal/library/auth/verify_test.go
+++ b/backend/internal/library/auth/verify_test.go
@@ -1,0 +1,185 @@
+package auth
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testRSAKey *rsa.PrivateKey
+
+func TestMain(m *testing.M) {
+	var err error
+	testRSAKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+// buildSignedJWT は RS256 署名付き JWT を生成する
+func buildSignedJWT(t *testing.T, key *rsa.PrivateKey, kid string, payload map[string]any) string {
+	t.Helper()
+
+	headerJSON, err := json.Marshal(map[string]string{"kid": kid, "alg": "RS256"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	sigInput := header + "." + payloadEnc
+	h := sha256.Sum256([]byte(sigInput))
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return sigInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// buildRawJWT はカスタムヘッダーで JWT を生成する (署名検証不要なテスト用)
+func buildRawJWT(t *testing.T, header, payload map[string]any, sig string) string {
+	t.Helper()
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := base64.RawURLEncoding.EncodeToString(headerJSON)
+	p := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return h + "." + p + "." + sig
+}
+
+func Test_extractKid(t *testing.T) {
+	t.Parallel()
+
+	validToken := buildSignedJWT(t, testRSAKey, "key-1", map[string]any{"sub": "user-1"})
+
+	tests := map[string]struct {
+		token   string
+		wantKid string
+		wantErr string
+	}{
+		"正常系_有効なヘッダーから_kid_を抽出する": {
+			token:   validToken,
+			wantKid: "key-1",
+		},
+		"異常系_3_パート未満のトークンはエラーを返す": {
+			token:   "a.b",
+			wantErr: "malformed token",
+		},
+		"異常系_ヘッダーが_base64_デコードできない場合はエラーを返す": {
+			token:   "!!!invalid!!!.payload.sig",
+			wantErr: "decode header",
+		},
+		"異常系_RS256_以外のアルゴリズムはエラーを返す": {
+			token:   buildRawJWT(t, map[string]any{"kid": "k", "alg": "HS256"}, map[string]any{}, "sig"),
+			wantErr: "unexpected alg",
+		},
+		"異常系_kid_が空の場合はエラーを返す": {
+			token:   buildRawJWT(t, map[string]any{"kid": "", "alg": "RS256"}, map[string]any{}, "sig"),
+			wantErr: "kid missing",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := extractKid(tt.token)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantKid {
+				t.Errorf("kid = %q, want %q", got, tt.wantKid)
+			}
+		})
+	}
+}
+
+func Test_verifyRS256(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().Add(time.Hour).Unix()
+	past := time.Now().Add(-time.Hour).Unix()
+
+	validToken := buildSignedJWT(t, testRSAKey, "k1", map[string]any{
+		"sub": "user-1", "custom:tenantId": "tenant-1", "exp": future,
+	})
+
+	parts := strings.SplitN(validToken, ".", 3)
+	tamperedToken := parts[0] + "." + parts[1] + "." + base64.RawURLEncoding.EncodeToString(make([]byte, 256))
+
+	tests := map[string]struct {
+		token   string
+		key     *rsa.PublicKey
+		wantErr string
+	}{
+		"正常系_有効な署名と有効期限のトークンは_claims_を返す": {
+			token: validToken,
+			key:   &testRSAKey.PublicKey,
+		},
+		"異常系_期限切れトークンはエラーを返す": {
+			token:   buildSignedJWT(t, testRSAKey, "k1", map[string]any{"exp": past}),
+			key:     &testRSAKey.PublicKey,
+			wantErr: "token expired",
+		},
+		"異常系_改ざんされた署名はエラーを返す": {
+			token:   tamperedToken,
+			key:     &testRSAKey.PublicKey,
+			wantErr: "invalid signature",
+		},
+		"異常系_3_パート未満のトークンはエラーを返す": {
+			token:   "a.b",
+			key:     &testRSAKey.PublicKey,
+			wantErr: "malformed token",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := verifyRS256(tt.token, tt.key)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/infra/lib/constructs/dynamodb-table.ts
+++ b/infra/lib/constructs/dynamodb-table.ts
@@ -24,7 +24,8 @@ export class DynamoDbTable extends Construct {
 
     this.table = new dynamodb.Table(this, "Table", {
       tableName: `${props.envName}-realtime-event-table`,
-      partitionKey: { name: "event_id", type: dynamodb.AttributeType.STRING }, // パーティションキーは event_id (UUID 文字列) 固定
+      partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: cdk.RemovalPolicy.DESTROY, // スタック削除時にテーブルも削除する (本番運用時は RETAIN 推奨)
     });

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -825,15 +825,23 @@ exports[`snapshot 1`] = `
       "Properties": {
         "AttributeDefinitions": [
           {
-            "AttributeName": "event_id",
+            "AttributeName": "pk",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "sk",
             "AttributeType": "S",
           },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
-            "AttributeName": "event_id",
+            "AttributeName": "pk",
             "KeyType": "HASH",
+          },
+          {
+            "AttributeName": "sk",
+            "KeyType": "RANGE",
           },
         ],
         "TableName": "dev-realtime-event-table",


### PR DESCRIPTION
# Pull Request

## 概要

v2 の締め作業として、DynamoDB テーブルのスキーマを pk/sk 構成に変更する。
合わせて Lambda Authorizer・JWT 検証のユニットテストを追加し、CI ワークフローを再編する。

## 変更内容

- `dynamodb-table.ts`: partitionKey を `event_id` から `pk` (String) に変更し、sortKey `sk` (String) を追加
- スナップショット更新
- Lambda Authorizer のチャンネルパス照合ロジックのユニットテストを追加 (`tenantId`/`userId` 欠如ケースを含む)
- `library/auth/` の JWT 署名検証・claims 抽出のユニットテストを追加
- CI ワークフローを `.yml` → `.yaml` にリネームし、共通パスを `ci-common.yaml` に集約

> [!NOTE]
> e2e 疎通確認は issue #113 (Pre Sign-up Lambda) の実装完了後に実施する。
> 正規のサインアップフローを通した end-to-end 確認にするため、#113 を先行させる方針とした。

## 関連 Issue / Discussion

- Closes #112
- Blocked by #113 (e2e 疎通確認のみ)

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] 関連するテストが通ることを確認 (`make test`)
- [x] `cdk deploy` でテーブルの再作成を確認

## レビュー観点

- `pk = tenantId#userId`、`sk = orderId` の設計が Issue #112 および v2 設計書と一致していること
- Lambda Authorizer テストで `tenantId`/`userId` の一致・不一致・欠如ケースが網羅されていること
- `ci-common.yaml` への共通パス集約により CI トリガーが適切に分離されていること