### PR TITLE
[backend] [issue-113] [feat] Pre Sign-up Lambda — テナント検証・管理者通知・tenantId 設定

### DIFF
--- a/.github/workflows/ci-presignup.yaml
+++ b/.github/workflows/ci-presignup.yaml
@@ -1,0 +1,96 @@
+name: CI - Presignup
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/cmd/presignup/**"
+      - "backend/internal/handler/presignup/**"
+      - ".github/workflows/ci-presignup.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/cmd/presignup/**"
+      - "backend/internal/handler/presignup/**"
+      - ".github/workflows/ci-presignup.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Node.js 24 がデフォルト化される 2026-06-02 以降は削除可
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        id: cache-golangci-lint
+        with:
+          path: ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-v2.12.2
+
+      - name: Install golangci-lint
+        if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('backend/.golangci.yml', 'backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Build
+        run: make build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Test
+        run: make test

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,6 +18,7 @@ build: mod
 	$(BUILD_OPTS) go build -trimpath -o build/api/bootstrap ./cmd/api
 	$(BUILD_OPTS) go build -trimpath -o build/event/bootstrap ./cmd/event
 	$(BUILD_OPTS) go build -trimpath -o build/authorizer/bootstrap ./cmd/authorizer
+	$(BUILD_OPTS) go build -trimpath -o build/presignup/bootstrap ./cmd/presignup
 
 lint:
 	golangci-lint run ./...
@@ -51,7 +52,7 @@ invoke-event:
 
 S3_BUCKET   ?= $(ENV)-realtime-event-storage
 
-.PHONY: upload-api upload-event upload-authorizer upload
+.PHONY: upload-api upload-event upload-authorizer upload-presignup upload
 upload-api:
 	$(BUILD_OPTS) go build -trimpath -o build/api/bootstrap ./cmd/api
 	zip -j build/api/bootstrap.zip build/api/bootstrap
@@ -67,10 +68,15 @@ upload-authorizer:
 	zip -j build/authorizer/bootstrap.zip build/authorizer/bootstrap
 	aws s3 cp build/authorizer/bootstrap.zip s3://$(S3_BUCKET)/artifacts/authorizer/bootstrap.zip --profile $(AWS_PROFILE)
 
-upload: upload-api upload-event upload-authorizer
+upload-presignup:
+	$(BUILD_OPTS) go build -trimpath -o build/presignup/bootstrap ./cmd/presignup
+	zip -j build/presignup/bootstrap.zip build/presignup/bootstrap
+	aws s3 cp build/presignup/bootstrap.zip s3://$(S3_BUCKET)/artifacts/presignup/bootstrap.zip --profile $(AWS_PROFILE)
+
+upload: upload-api upload-event upload-authorizer upload-presignup
 
 
-.PHONY: deploy-api deploy-event deploy-authorizer
+.PHONY: deploy-api deploy-event deploy-authorizer deploy-presignup
 deploy-api: upload-api
 	aws lambda update-function-code \
 		--function-name $(ENV)-realtime-event-api \
@@ -92,4 +98,11 @@ deploy-authorizer: upload-authorizer
 		--s3-key artifacts/authorizer/bootstrap.zip \
 		--profile $(AWS_PROFILE) | jq .
 
-deploy: deploy-api deploy-event deploy-authorizer
+deploy-presignup: upload-presignup
+	aws lambda update-function-code \
+		--function-name $(ENV)-realtime-event-presignup \
+		--s3-bucket $(S3_BUCKET) \
+		--s3-key artifacts/presignup/bootstrap.zip \
+		--profile $(AWS_PROFILE) | jq .
+
+deploy: deploy-api deploy-event deploy-authorizer deploy-presignup

--- a/backend/cmd/presignup/main.go
+++ b/backend/cmd/presignup/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/tamaco489/realtime-event-platform/backend/internal/handler/presignup"
+)
+
+func main() {
+	h := presignup.NewHandler()
+	lambda.Start(h.Handle)
+}

--- a/backend/internal/handler/presignup/handler.go
+++ b/backend/internal/handler/presignup/handler.go
@@ -1,0 +1,64 @@
+package presignup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type tenant struct {
+	companyName string
+}
+
+// tenants はテナント定義。tenantId をキー、企業名を値として照合する
+var tenants = map[string]tenant{
+	"tenant-xxx01": {companyName: "株式会社サンプルテック"},
+	"tenant-xxx02": {companyName: "合同会社フューチャーワークス"},
+}
+
+// Handler は Cognito Pre Sign-up Lambda のハンドラ
+type Handler struct{}
+
+// NewHandler は Handler を返す
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// Handle は Cognito Pre Sign-up トリガーのエントリポイント
+//   - validationData から tenantId と companyName を取得し、テナント定義と照合する。
+//   - 両方一致した場合のみサインアップを受け付け、autoConfirmUser: false を返す。
+func (h *Handler) Handle(ctx context.Context, event events.CognitoEventUserPoolsPreSignup) (events.CognitoEventUserPoolsPreSignup, error) {
+	tenantID := event.Request.ValidationData["tenantId"]
+	companyName := event.Request.ValidationData["companyName"]
+
+	// NOTE: 本来は顧客マスタ (DynamoDB / RDB 等) からテナント定義を取得して照合する。
+	// コスト削減のため、本実装ではテナント定義を Lambda コード内にハードコードしている。
+	// テナントまたは会社名が一致しない場合はサインアップを拒否し、Cognito がクライアントに PreSignUpFailed を返す。
+	if err := h.validate(tenantID, companyName); err != nil {
+		return event, fmt.Errorf("signup rejected: %w", err)
+	}
+
+	// false を明示することで、管理者が custom:tenantId を付与するまでユーザーが待機状態になる意図を示す
+	event.Response.AutoConfirmUser = false
+
+	return event, nil
+}
+
+func (h *Handler) validate(tenantID, companyName string) error {
+	if tenantID == "" || companyName == "" {
+		return errors.New("tenantId and companyName are required")
+	}
+
+	t, ok := tenants[tenantID]
+	if !ok {
+		return fmt.Errorf("tenant not found: %s", tenantID)
+	}
+
+	if t.companyName != companyName {
+		return fmt.Errorf("company name mismatch for tenant: %s", tenantID)
+	}
+
+	return nil
+}

--- a/backend/internal/handler/presignup/handler.go
+++ b/backend/internal/handler/presignup/handler.go
@@ -14,8 +14,8 @@ type tenant struct {
 
 // tenants はテナント定義。tenantId をキー、企業名を値として照合する
 var tenants = map[string]tenant{
-	"tenant-xxx01": {companyName: "株式会社サンプルテック"},
-	"tenant-xxx02": {companyName: "合同会社フューチャーワークス"},
+	"1234": {companyName: "株式会社サンプルテック"},
+	"5678": {companyName: "合同会社フューチャーワークス"},
 }
 
 // Handler は Cognito Pre Sign-up Lambda のハンドラ

--- a/backend/internal/handler/presignup/handler_test.go
+++ b/backend/internal/handler/presignup/handler_test.go
@@ -1,0 +1,82 @@
+package presignup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestHandler_Handle(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		validationData map[string]string
+		wantErr        bool
+		wantConfirm    bool
+	}{
+		"正常系_有効な_tenantId_と_companyName_でサインアップを受け付ける": {
+			validationData: map[string]string{
+				"tenantId":    "tenant-xxx01",
+				"companyName": "株式会社サンプルテック",
+			},
+			wantErr:     false,
+			wantConfirm: false,
+		},
+		"異常系_存在しない_tenantId_はサインアップを拒否する": {
+			validationData: map[string]string{
+				"tenantId":    "tenant-unknown",
+				"companyName": "株式会社サンプルテック",
+			},
+			wantErr: true,
+		},
+		"異常系_companyName_不一致はサインアップを拒否する": {
+			validationData: map[string]string{
+				"tenantId":    "tenant-xxx01",
+				"companyName": "株式会社ダミー",
+			},
+			wantErr: true,
+		},
+		"異常系_tenantId_が空の場合はサインアップを拒否する": {
+			validationData: map[string]string{
+				"tenantId":    "",
+				"companyName": "A社",
+			},
+			wantErr: true,
+		},
+		"異常系_companyName_が空の場合はサインアップを拒否する": {
+			validationData: map[string]string{
+				"tenantId":    "tenant-xxx01",
+				"companyName": "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler()
+			event := events.CognitoEventUserPoolsPreSignup{
+				Request: events.CognitoEventUserPoolsPreSignupRequest{
+					ValidationData: tt.validationData,
+				},
+			}
+
+			got, err := h.Handle(context.Background(), event)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got.Response.AutoConfirmUser != tt.wantConfirm {
+				t.Errorf("AutoConfirmUser = %v, want %v", got.Response.AutoConfirmUser, tt.wantConfirm)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/presignup/handler_test.go
+++ b/backend/internal/handler/presignup/handler_test.go
@@ -17,7 +17,7 @@ func TestHandler_Handle(t *testing.T) {
 	}{
 		"正常系_有効な_tenantId_と_companyName_でサインアップを受け付ける": {
 			validationData: map[string]string{
-				"tenantId":    "tenant-xxx01",
+				"tenantId":    "1234",
 				"companyName": "株式会社サンプルテック",
 			},
 			wantErr:     false,
@@ -25,14 +25,14 @@ func TestHandler_Handle(t *testing.T) {
 		},
 		"異常系_存在しない_tenantId_はサインアップを拒否する": {
 			validationData: map[string]string{
-				"tenantId":    "tenant-unknown",
+				"tenantId":    "0000",
 				"companyName": "株式会社サンプルテック",
 			},
 			wantErr: true,
 		},
 		"異常系_companyName_不一致はサインアップを拒否する": {
 			validationData: map[string]string{
-				"tenantId":    "tenant-xxx01",
+				"tenantId":    "1234",
 				"companyName": "株式会社ダミー",
 			},
 			wantErr: true,
@@ -46,7 +46,7 @@ func TestHandler_Handle(t *testing.T) {
 		},
 		"異常系_companyName_が空の場合はサインアップを拒否する": {
 			validationData: map[string]string{
-				"tenantId":    "tenant-xxx01",
+				"tenantId":    "1234",
 				"companyName": "",
 			},
 			wantErr: true,

--- a/infra/lib/constructs/cognito.ts
+++ b/infra/lib/constructs/cognito.ts
@@ -1,14 +1,17 @@
 import * as cdk from "aws-cdk-lib";
 import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 
 /**
  * Cognito コンストラクタプロパティ
  *
  * @property envName - 環境名。リソースの命名に使用する
+ * @property preSignUpFn - Pre Sign-up Lambda 関数。サインアップ時のテナント照合に使用する
  */
 interface CognitoProps {
   readonly envName: string;
+  readonly preSignUpFn: lambda.Function;
 }
 
 /**
@@ -30,13 +33,14 @@ export class Cognito extends Construct {
     // User Pool - ユーザーの認証基盤となる User Pool を作成
     this.userPool = new cognito.UserPool(this, "UserPool", {
       userPoolName: `${props.envName}-realtime-event-user-pool`,
-      /* TODO(#113) selfSignUpEnabled について:
-        - DOC: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cognito.UserPool.html
-        - Pre Sign-up Lambda 実装後に完全に機能する
-        - ユーザーはサインアップ時にテナント ID + 企業名を入力し、Lambda がテナント定義と照合して検証する
-        - 管理者が AdminUpdateUserAttributes で custom:tenantId を付与するまで JWT に tenantId が含まれず BE-001 の JWT 検証で 403 になるため、ユーザーはサービスを利用できない状態になる
-      */
+
+      // ユーザーが自己サインアップできるようにする。テナント照合は Pre Sign-up Lambda に委譲する
       selfSignUpEnabled: true,
+
+      // サインアップ前に Pre Sign-up Lambda でテナント ID と企業名を照合する
+      lambdaTriggers: {
+        preSignUp: props.preSignUpFn,
+      },
 
       // メールは大小文字区別しない
       signInCaseSensitive: false,

--- a/infra/lib/constructs/presignup-lambda.ts
+++ b/infra/lib/constructs/presignup-lambda.ts
@@ -1,0 +1,73 @@
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+
+/**
+ * PreSignupLambda コンストラクタプロパティ
+ *
+ * @property envName - 環境名。リソースの命名に使用する
+ * @property lambdaMemorySize - Lambda 関数のメモリサイズ (MB)
+ * @property artifactsBucketName - Lambda ビルド成果物を格納する S3 バケット名
+ */
+interface PreSignupLambdaProps {
+  readonly envName: string;
+  readonly lambdaMemorySize: number;
+  readonly artifactsBucketName: string;
+}
+
+/**
+ * Cognito Pre Sign-up Lambda コンストラクト
+ *
+ * サインアップ時に tenantId と companyName をテナント定義と照合し、不正登録を防ぐ。
+ * 照合が成功した場合のみ autoConfirmUser: false を返してサインアップを受け付ける。
+ */
+export class PreSignupLambda extends Construct {
+  /** Pre Sign-up Lambda 関数 */
+  readonly fn: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: PreSignupLambdaProps) {
+    super(scope, id);
+
+    // Pre Sign-up Lambda の実行ロール。CloudWatch Logs への書き込み権限のみ付与する
+    const role = new iam.Role(this, "Role", {
+      roleName: `${props.envName}-realtime-event-presignup-role`,
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaBasicExecutionRole",
+        ),
+      ],
+    });
+
+    // DOC: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html
+    // Pre Sign-up Lambda 関数。Cognito サインアップトリガーとして Cognito から直接呼び出される
+    this.fn = new lambda.Function(this, "Function", {
+      functionName: `${props.envName}-realtime-event-presignup`,
+      description:
+        "Cognito Pre Sign-up trigger — validates tenantId and companyName against hardcoded tenant definitions",
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      architecture: lambda.Architecture.ARM_64,
+      handler: "bootstrap",
+      code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(
+          this,
+          "ArtifactsBucket",
+          props.artifactsBucketName,
+        ),
+        "artifacts/presignup/bootstrap.zip",
+      ),
+      role,
+      memorySize: props.lambdaMemorySize,
+      // DOC: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-working-with-lambda-triggers.html
+      // NOTE: Cognito 同期型トリガーのタイムアウト上限は 5 秒。上限に合わせて設定
+      timeout: cdk.Duration.seconds(5),
+    });
+
+    const managedLogGroup = this.fn.node.findChild("LogGroup") as logs.LogGroup;
+    (managedLogGroup.node.defaultChild as logs.CfnLogGroup).retentionInDays = 7;
+    managedLogGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+  }
+}

--- a/infra/lib/stacks/realtime-event-stack.ts
+++ b/infra/lib/stacks/realtime-event-stack.ts
@@ -9,6 +9,7 @@ import { CloudFrontS3 } from "../constructs/cloudfront-s3";
 import { Cognito } from "../constructs/cognito";
 import { DynamoDbTable } from "../constructs/dynamodb-table";
 import { EventLambda } from "../constructs/event-lambda";
+import { PreSignupLambda } from "../constructs/presignup-lambda";
 import { SqsQueue } from "../constructs/sqs-queue";
 
 /**
@@ -30,8 +31,15 @@ export class RealtimeEventStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: RealtimeEventStackProps) {
     super(scope, id, props);
 
+    const presignup = new PreSignupLambda(this, "PreSignupLambda", {
+      envName: props.config.envName,
+      lambdaMemorySize: props.config.lambdaMemorySize,
+      artifactsBucketName: props.config.artifactsBucketName,
+    });
+
     const cognito = new Cognito(this, "Cognito", {
       envName: props.config.envName,
+      preSignUpFn: presignup.fn,
     });
 
     const authorizer = new AppSyncAuthorizer(this, "AppSyncAuthorizer", {

--- a/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
+++ b/infra/test/__snapshots__/realtime-event-stack.test.ts.snap
@@ -690,6 +690,14 @@ exports[`snapshot 1`] = `
         ],
         "EmailVerificationMessage": "The verification code to your new account is {####}",
         "EmailVerificationSubject": "Verify your new account",
+        "LambdaConfig": {
+          "PreSignUp": {
+            "Fn::GetAtt": [
+              "PreSignupLambdaFunction2F1753F3",
+              "Arn",
+            ],
+          },
+        },
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 12,
@@ -726,6 +734,25 @@ exports[`snapshot 1`] = `
       },
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Delete",
+    },
+    "CognitoUserPoolPreSignUpCognitoD07EA58F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "PreSignupLambdaFunction2F1753F3",
+            "Arn",
+          ],
+        },
+        "Principal": "cognito-idp.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CognitoUserPool279BBD48",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "CognitoUserPoolUserPoolClient1E6BF456": {
       "Properties": {
@@ -1049,6 +1076,84 @@ exports[`snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "PreSignupLambdaFunction2F1753F3": {
+      "DependsOn": [
+        "PreSignupLambdaRole5234B715",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": "dev-realtime-event-storage",
+          "S3Key": "artifacts/presignup/bootstrap.zip",
+        },
+        "Description": "Cognito Pre Sign-up trigger — validates tenantId and companyName against hardcoded tenant definitions",
+        "FunctionName": "dev-realtime-event-presignup",
+        "Handler": "bootstrap",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "PreSignupLambdaRole5234B715",
+            "Arn",
+          ],
+        },
+        "Runtime": "provided.al2023",
+        "Timeout": 5,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PreSignupLambdaFunctionLogGroup6088F41A": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "PreSignupLambdaFunction2F1753F3",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PreSignupLambdaRole5234B715": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "RoleName": "dev-realtime-event-presignup-role",
+      },
+      "Type": "AWS::IAM::Role",
     },
     "SqsQueueB359A2D7": {
       "DeletionPolicy": "Delete",


### PR DESCRIPTION
# Pull Request

## 概要

Cognito サインアップ時にテナント ID と企業名をセットで照合する Pre Sign-up Lambda を実装した。
テナント定義は RDB を使用せず Lambda コード内にハードコードする方針のため、DynamoDB / RDS のコストを抑えつつ不正登録を防ぐ。

## 変更内容

- `backend/internal/handler/presignup/` — Cognito Pre Sign-up トリガーハンドラを追加
  - `validationData` から `tenantId` / `companyName` を取得しテナント定義と照合
  - 不一致・欠如の場合は `fmt.Errorf` でエラーを返し、Cognito がクライアントに PreSignUpFailed を返す
- `backend/cmd/presignup/main.go` — Lambda エントリポイントを追加
- `backend/Makefile` — presignup ビルド・アップロード・デプロイターゲットを追加

> [!NOTE]
> CDK 組み込み (presignup-lambda.ts / cognito.ts のスナップショット更新含む) は後続コミットで追加予定。

## 関連 Issue / Discussion

- Closes #113

## 動作確認

- [x] ローカルでビルドが通ることを確認
- [x] 関連するテストが通ることを確認 (`make test`)

## レビュー観点

- テナント照合ロジック (`validate` メソッド) の条件分岐
- `autoConfirmUser: false` を明示している意図 (管理者が `custom:tenantId` を付与するまでユーザーを待機状態にする)