### PR TITLE
[backend] [frontend] [fix] prd E2E 検証で発覚した認証・バリデーション不具合を修正

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -93,7 +93,7 @@ deploy-event: upload-event
 
 deploy-authorizer: upload-authorizer
 	aws lambda update-function-code \
-		--function-name $(ENV)-realtime-event-authorizer \
+		--function-name $(ENV)-realtime-event-appsync-authorizer \
 		--s3-bucket $(S3_BUCKET) \
 		--s3-key artifacts/authorizer/bootstrap.zip \
 		--profile $(AWS_PROFILE) | jq .

--- a/backend/internal/handler/api/handler.go
+++ b/backend/internal/handler/api/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.EventID == "" || req.EventName == "" || req.SeatType == "" {
+	if strings.TrimSpace(req.EventID) == "" || strings.TrimSpace(req.EventName) == "" || req.SeatType == "" {
 		writeJSONError(w, "event_id, event_name and seat_type are required", http.StatusBadRequest)
 		return
 	}
@@ -93,7 +93,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // authenticate はローカル環境では固定クレームを返す。本番環境では JWT を検証する。
 func (h *Handler) authenticate(w http.ResponseWriter, r *http.Request) (*auth.Claims, bool) {
 	if h.isLocal {
-		return &auth.Claims{TenantID: "tenant-xxx01", UserID: "local-user-id"}, true
+		return &auth.Claims{
+			TenantID: "1234",
+			UserID:   "00000000-0000-4000-a000-000000000001",
+		}, true
 	}
 
 	authHeader := r.Header.Get("Authorization")

--- a/backend/internal/handler/authorizer/handler.go
+++ b/backend/internal/handler/authorizer/handler.go
@@ -47,7 +47,8 @@ type requestContext struct {
 
 // Handle は AppSync Events Lambda Authorizer のエントリポイント
 //   - クライアントが WebSocket で Subscribe する際に AppSync から呼び出され、チャンネルへのアクセス可否を判定。
-//   - JWT を Cognito JWKS で検証し、チャンネルパスの tenantId, userId と claims を照合する。
+//   - EventConnect: JWT 検証のみ。Channel は空文字のため照合をスキップする。
+//   - EventSubscribe: JWT 検証後、チャンネルパスの tenantId, userId と claims を照合する。
 //   - 承認時は TTLOverride: 300 (5 分) でキャッシュする。
 func (h *Handler) Handle(ctx context.Context, req Request) (Response, error) {
 	token := strings.TrimPrefix(req.AuthorizationToken, "Bearer ")
@@ -58,6 +59,14 @@ func (h *Handler) Handle(ctx context.Context, req Request) (Response, error) {
 		return Response{
 			IsAuthorized: false,
 			TTLOverride:  0,
+		}, nil
+	}
+
+	// CONNECT フェーズは Channel が空文字。JWT 検証のみで承認する
+	if req.RequestContext.Operation == "EVENT_CONNECT" {
+		return Response{
+			IsAuthorized: true,
+			TTLOverride:  authzCacheTTLSec,
 		}, nil
 	}
 

--- a/backend/internal/handler/authorizer/handler_test.go
+++ b/backend/internal/handler/authorizer/handler_test.go
@@ -20,54 +20,78 @@ func TestHandler_Handle(t *testing.T) {
 		mockClaims  *auth.Claims
 		mockAuthErr error
 		token       string
+		operation   string
 		channel     string
 		wantAuth    bool
 		wantTTL     int
 	}{
-		"正常系_有効な_JWT_でチャンネルアクセスを承認する": {
+		"正常系_EventConnect_で有効な_JWT_なら承認する": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_CONNECT",
+			channel:    "",
+			mockClaims: validClaims,
+			wantAuth:   true,
+			wantTTL:    authzCacheTTLSec,
+		},
+		"異常系_EventConnect_で_JWT_検証エラーは_isAuthorized_false_を返す": {
+			token:       "Bearer bad.token.here",
+			operation:   "EventConnect",
+			channel:     "",
+			mockAuthErr: errors.New("invalid signature"),
+			wantAuth:    false,
+			wantTTL:     0,
+		},
+		"正常系_EventSubscribe_で有効な_JWT_とチャンネルパスが一致すれば承認する": {
+			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/tenant-abc/user-123",
 			mockClaims: validClaims,
 			wantAuth:   true,
 			wantTTL:    authzCacheTTLSec,
 		},
-		"異常系_JWT_検証エラーは_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_で_JWT_検証エラーは_isAuthorized_false_を返す": {
 			token:       "Bearer bad.token.here",
+			operation:   "EventSubscribe",
 			channel:     "/tickets/orders/tenant-abc/user-123",
 			mockAuthErr: errors.New("invalid signature"),
 			wantAuth:    false,
 			wantTTL:     0,
 		},
-		"異常系_チャンネルパスのセグメントが不足している場合は_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_でチャンネルパスのセグメントが不足している場合は_isAuthorized_false_を返す": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/tenant-abc",
 			mockClaims: validClaims,
 			wantAuth:   false,
 			wantTTL:    0,
 		},
-		"異常系_tenantId_不一致は_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_で_tenantId_不一致は_isAuthorized_false_を返す": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/other-tenant/user-123",
 			mockClaims: validClaims,
 			wantAuth:   false,
 			wantTTL:    0,
 		},
-		"異常系_userId_不一致は_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_で_userId_不一致は_isAuthorized_false_を返す": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/tenant-abc/other-user",
 			mockClaims: validClaims,
 			wantAuth:   false,
 			wantTTL:    0,
 		},
-		"異常系_claims_の_tenantId_が空の場合は_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_で_claims_の_tenantId_が空の場合は_isAuthorized_false_を返す": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/tenant-abc/user-123",
 			mockClaims: &auth.Claims{TenantID: "", UserID: "user-123"},
 			wantAuth:   false,
 			wantTTL:    0,
 		},
-		"異常系_claims_の_userId_が空の場合は_isAuthorized_false_を返す": {
+		"異常系_EventSubscribe_で_claims_の_userId_が空の場合は_isAuthorized_false_を返す": {
 			token:      "Bearer valid.token.here",
+			operation:  "EVENT_SUBSCRIBE",
 			channel:    "/tickets/orders/tenant-abc/user-123",
 			mockClaims: &auth.Claims{TenantID: "tenant-abc", UserID: ""},
 			wantAuth:   false,
@@ -83,7 +107,7 @@ func TestHandler_Handle(t *testing.T) {
 			req := Request{
 				AuthorizationToken: tt.token,
 				RequestContext: requestContext{
-					Operation: "EVENT_SUBSCRIBE",
+					Operation: tt.operation,
 					Channel:   tt.channel,
 				},
 			}

--- a/frontend/src/app/amplify.ts
+++ b/frontend/src/app/amplify.ts
@@ -11,7 +11,7 @@ Amplify.configure({
     Events: {
       endpoint: import.meta.env.VITE_APPSYNC_HTTP_URL ?? "",
       region: import.meta.env.VITE_AWS_REGION ?? "ap-northeast-1",
-      defaultAuthMode: "userPool",
+      defaultAuthMode: "lambda",
     },
   },
 });

--- a/frontend/src/features/auth/model/useSignInForm.ts
+++ b/frontend/src/features/auth/model/useSignInForm.ts
@@ -39,6 +39,18 @@ export function useSignInForm(onSignedIn: () => void) {
       // サインイン完了後のコールバックを呼び出す (例: サインイン画面を閉じる)
       onSignedIn();
     } catch (err) {
+      // ページリロード後に Amplify の localStorage セッションが残っている場合、
+      // signIn が失敗するため既存セッションからクレームを取得してサインイン状態にする
+      if (err instanceof Error && err.message.includes("There is already a signed in user")) {
+        try {
+          const claims = await getAuthClaims();
+          setAuth(claims.tenantId, claims.userId);
+          onSignedIn();
+          return;
+        } catch {
+          // フォールスルー: 通常のエラー処理へ
+        }
+      }
       setError(err instanceof Error ? err.message : "サインインに失敗しました");
     } finally {
       setLoading(false);

--- a/frontend/src/features/event-feed/api/useEventSubscription.ts
+++ b/frontend/src/features/event-feed/api/useEventSubscription.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { EventsChannel } from "aws-amplify/api";
+import { fetchAuthSession, signOut } from "aws-amplify/auth";
 
 import { config } from "@app/config";
 import { events } from "@shared/api/appsync";
@@ -33,6 +34,7 @@ interface ReceivedEvent {
  * 受信イベントを useEventFeedStore に追加する。
  * tenantId・userId のどちらかが null の場合は接続しない。
  * サインアウト時は clearAuth() により両値が null になり、useEffect のクリーンアップで自動切断する。
+ * Subscription エラー時は Cognito セッションを破棄して再サインインを促す。
  * VITE_APP_ENV が "local" のときは接続しない。イベント追加は postTicketOrder が直接行う。
  *
  * @returns error - 接続エラーメッセージ。正常時は null
@@ -44,6 +46,7 @@ export function useEventSubscription(): { error: string | null } {
   // テナント別チャンネルパスの構築に使用する。管理者が付与するまで tenantId は null になる
   const tenantId = useAuthStore((s) => s.tenantId);
   const userId = useAuthStore((s) => s.userId);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -52,18 +55,47 @@ export function useEventSubscription(): { error: string | null } {
 
     // 購読するチャンネルパスを構築
     const channel = `tickets/orders/${tenantId}/${userId}`;
-    switch (config.appEnv) {
-      case "prd":
-        return subscribeChannel(channel, addEvent, setError);
-      case "local":
-        console.log(
-          "[Subscription] ローカル環境のため WebSocket 接続をスキップ。イベント追加は postTicketOrder のモック実装が直接行う"
-        );
-        return;
-      default:
-        throw new Error(`Unknown VITE_APP_ENV: ${config.appEnv}`);
+
+    if (config.appEnv === "local") {
+      console.log(
+        "[Subscription] ローカル環境のため WebSocket 接続をスキップ。イベント追加は postTicketOrder のモック実装が直接行う"
+      );
+      return;
     }
-  }, [addEvent, tenantId, userId]);
+    if (config.appEnv !== "prd") {
+      throw new Error(`Unknown VITE_APP_ENV: ${config.appEnv}`);
+    }
+
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+
+    fetchAuthSession()
+      .then((session) => {
+        if (cancelled) return;
+        const idToken = session.tokens?.idToken?.toString();
+        if (!idToken) {
+          setError("ID Token の取得に失敗しました");
+          return;
+        }
+        // Subscription エラー時は Cognito セッションを破棄して再サインインへ誘導する
+        cleanup = subscribeChannel(
+          channel,
+          addEvent,
+          () => {
+            signOut().finally(() => clearAuth());
+          },
+          idToken
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setError("セッション取得に失敗しました");
+      });
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [addEvent, tenantId, userId, clearAuth]);
 
   return { error };
 }
@@ -73,13 +105,15 @@ export function useEventSubscription(): { error: string | null } {
  *
  * @param channel - 購読するチャンネルパス (例: "tickets/orders/{tenantId}/{userId}")
  * @param addEvent - 受信したイベントをストアに追加するコールバック
- * @param setError - エラーメッセージをセットするコールバック
+ * @param onSessionExpired - エラー発生時のコールバック。Cognito セッションを破棄して再サインインへ誘導する
+ * @param idToken - Cognito ID Token。Lambda Authorizer に渡す。custom:tenantId を含む
  * @returns チャンネルをクローズするクリーンアップ関数
  */
 function subscribeChannel(
   channel: string,
   addEvent: (item: EventItem) => void,
-  setError: (msg: string) => void
+  onSessionExpired: () => void,
+  idToken: string
 ): () => void {
   console.log(`[Subscription] 開始: ${channel}`);
 
@@ -88,23 +122,23 @@ function subscribeChannel(
 
   // AppSync Events チャンネルに接続してイベントを購読
   events
-    // 接続開始。接続成功後に then() で購読開始、失敗したら catch() でエラーハンドリングする
-    .connect(channel)
+    // ID Token を明示的に渡す。defaultAuthMode: "userPool" は Access Token を送るため
+    // Lambda Authorizer が custom:tenantId を取得できない問題を回避する
+    .connect(channel, { authMode: "lambda", authToken: idToken })
 
     // 接続成功
     .then((c) => {
       ch = c;
-      // 購読開始。受信イベントは addEvent でストアに追加、エラーは setError でエラーメッセージをセットする
       c.subscribe({
         next: (data: ReceivedEvent) => {
           console.log("[Subscription] next:", JSON.stringify(data));
           addEvent(buildEventItem(data.event.event_type, data.event.payload));
         },
 
-        // 購読エラーは接続エラーと同様に扱う
+        // Token 期限切れ等による接続エラー → Cognito セッション破棄で再サインインへ誘導する
         error: (err: unknown) => {
           console.error("[Subscription] error:", err);
-          setError(err instanceof Error ? err.message : "Subscription 接続に失敗しました");
+          onSessionExpired();
         },
       });
     })
@@ -112,7 +146,7 @@ function subscribeChannel(
     // 接続エラー
     .catch((err: unknown) => {
       console.error("[Subscription] connect error:", err);
-      setError(err instanceof Error ? err.message : "WebSocket 接続に失敗しました");
+      onSessionExpired();
     });
 
   return () => {

--- a/frontend/src/shared/api/http.ts
+++ b/frontend/src/shared/api/http.ts
@@ -1,6 +1,15 @@
+import { fetchAuthSession } from "aws-amplify/auth";
+
 import { config } from "@app/config";
 
 const BASE_URL = config.apiBaseUrl;
+
+async function getIdToken(): Promise<string> {
+  const session = await fetchAuthSession();
+  const token = session.tokens?.idToken?.toString();
+  if (!token) throw new Error("ID Token の取得に失敗しました");
+  return token;
+}
 
 /**
  * GET リクエストを送信する
@@ -9,7 +18,10 @@ const BASE_URL = config.apiBaseUrl;
  * @returns レスポンスを T 型にパースした値
  */
 export async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`);
+  const token = await getIdToken();
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<T>;
 }
@@ -22,9 +34,13 @@ export async function get<T>(path: string): Promise<T> {
  * @returns レスポンスを T 型にパースした値。ボディなし (202 等) の場合は undefined
  */
 export async function post<T>(path: string, body: unknown): Promise<T> {
+  const token = await getIdToken();
   const res = await fetch(`${BASE_URL}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
## 背景・動機

prd 環境での E2E 検証を通じて 4 件の不具合を発見・修正した。
いずれも AppSync WebSocket 接続、API 認証、入力バリデーションに関わる問題で、
サインイン後にリアルタイムイベント受信や注文送信が正常に動作しない状態だった。

## 変更内容

### Issue 001 — AppSync CONNECT フェーズで UnauthorizedException

AppSync Lambda Authorizer が `EVENT_CONNECT` 時に Channel が空文字であることを理由に拒否していた。
CONNECT フェーズは JWT 検証のみで承認するよう `handler.go` を修正し、テストを追加。
あわせて `Makefile` の `deploy-authorizer` ターゲットが誤った Lambda 関数名を参照していたため修正。

`amplify.ts` の `defaultAuthMode` を `"userPool"` から `"lambda"` に変更。
`"userPool"` のままだと Amplify が Access Token を AppSync に送るため、
Lambda Authorizer が `custom:tenantId` を取得できず認証に失敗していた。

### Issue 002 — POST /v1/tickets/orders で HTTP 401

`frontend/src/shared/api/http.ts` の `get()` / `post()` に `Authorization: Bearer <idToken>` ヘッダーがなく、
API Lambda が拒否していた。`getIdToken()` ヘルパーを追加してすべての API コールにヘッダーを付与。

### Issue 003 — event_id に空白文字を入力しても注文が通る

`handler.go` のバリデーションが `== ""` のみをチェックしており、空白のみの文字列を通過させていた。
`strings.TrimSpace()` を適用して修正。

### Issue 004 — Cognito ID Token 期限切れ後に Subscription が切断される

`useEventSubscription.ts` がマウント時に取得した静的トークンを使い続けるため、
1 時間後にトークンが失効すると Amplify 内部の再接続が失敗していた。
Subscription error / connect error 時に `signOut().finally(() => clearAuth())` でセッションを破棄し、
サインイン画面へ遷移させる実装に変更。

また、ページリロード後に Amplify の localStorage セッションが残っている場合に
`signIn()` が失敗する問題も `useSignInForm.ts` のフォールバック処理で対処。

> [!NOTE]
> Issue 004 のトークン期限切れシナリオは実時間での再現確認が難しいため、
> コードの論理確認と通常フローの E2E 確認に留まっている。

## 検証

prd 環境 (`https://d177lfq1m9lalw.cloudfront.net`) で以下のフローを確認済み。

- サインイン → WebSocket Subscription 開始
- 注文送信 → SQS → Event Lambda → AppSync → WebSocket → フロントエンド表示
- サインアウト → Subscription 切断 → サインイン画面への遷移
- 再サインイン → Subscription 再開

詳細な検証記録: `tmp/e2e/` 配下の HTML ファイルを参照